### PR TITLE
fix: static export

### DIFF
--- a/packages/react-server/lib/handlers/static.mjs
+++ b/packages/react-server/lib/handlers/static.mjs
@@ -47,14 +47,32 @@ export default async function staticHandler(dir, options = {}) {
       const isBrotli = acceptEncoding?.includes("br");
       const isGzip = acceptEncoding?.includes("gzip");
 
-      if (isBrotli && files.has(`${pathname}/index.html.br`)) {
-        pathname = `${pathname}/index.html.br`;
+      const basename = `${pathname}/index.html`.replace(/^\/+/g, "");
+      if (isBrotli && files.has(`${basename}.br`)) {
+        pathname = `${basename}.br`;
         contentEncoding = "br";
-      } else if (isGzip && files.has(`${pathname}/index.html.gz`)) {
-        pathname = `${pathname}/index.html.gz`;
+      } else if (isGzip && files.has(`${basename}.gz`)) {
+        pathname = `${basename}.gz`;
         contentEncoding = "gzip";
-      } else if (files.has(`${pathname}/index.html`)) {
-        pathname = `${pathname}/index.html`;
+      } else if (files.has(basename)) {
+        pathname = basename;
+      }
+    }
+
+    if (isRSC) {
+      const acceptEncoding = context.request.headers.get("accept-encoding");
+      const isBrotli = acceptEncoding?.includes("br");
+      const isGzip = acceptEncoding?.includes("gzip");
+
+      const basename = `${pathname}/x-component.rsc`.replace(/^\/+/g, "");
+      if (isBrotli && files.has(`${basename}.br`)) {
+        pathname = `${basename}.br`;
+        contentEncoding = "br";
+      } else if (isGzip && files.has(`${basename}.gz`)) {
+        pathname = `${basename}.gz`;
+        contentEncoding = "gzip";
+      } else if (files.has(basename)) {
+        pathname = basename;
       }
     }
 


### PR DESCRIPTION
Fixes static exporting of routes specified in the root configuration file. Correct URL instance is now used in the rendering context.

Static export now also renders with the `Accept` header set to `text/x-component`, and so exporting will work not just on initial loading of pages, but also on client-side navigation to the exported routes.

Static file handler now works for both HTML and RSC exports.

Fixes minor issue with filename formatting in the reporting of the static export.