### PR TITLE
fix: dev hmr

### DIFF
--- a/packages/react-server/lib/plugins/react-server.mjs
+++ b/packages/react-server/lib/plugins/react-server.mjs
@@ -65,7 +65,11 @@ export default function viteReactServer(type) {
 				window.$RefreshSig$ = () => (type) => type;
 				window.__vite_plugin_react_preamble_installed__ = true;
 				console.log("Hot Module Replacement installed.");
-				import("${__require.resolve("@lazarv/react-server/client/entry.client.jsx")}");
+        if (typeof __react_server_hydrate__ !== "undefined") {
+				  import("${__require.resolve(
+            "@lazarv/react-server/client/entry.client.jsx"
+          )}");
+        }
 			`;
       }
     },


### PR DESCRIPTION
Fixes HMR when rendering without any client components. When no client components used to render the HTML response the renderer will include the entry module for HMR, but it will not start hydration on the client.

In a production build when no client components were used rendering will not include any script tags and so there will be no hydration on the client.