### PR TITLE
fix: vite deps optimizer usage

### DIFF
--- a/examples/chakra-ui/app/Chakra.jsx
+++ b/examples/chakra-ui/app/Chakra.jsx
@@ -1,0 +1,4 @@
+"use client";
+
+import { Button, Spinner } from "@chakra-ui/react";
+export { Button, Spinner };

--- a/examples/chakra-ui/app/Providers.jsx
+++ b/examples/chakra-ui/app/Providers.jsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ChakraProvider } from "@chakra-ui/react";
+
+export default function Providers({ children }) {
+  return <ChakraProvider>{children}</ChakraProvider>;
+}

--- a/examples/chakra-ui/app/layout.jsx
+++ b/examples/chakra-ui/app/layout.jsx
@@ -1,0 +1,11 @@
+import Providers from "./Providers";
+
+export default function Layout({ children }) {
+  return (
+    <html lang="en">
+      <body>
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
+}

--- a/examples/chakra-ui/app/page.jsx
+++ b/examples/chakra-ui/app/page.jsx
@@ -1,0 +1,17 @@
+import { Suspense } from "react";
+
+import { Button, Spinner } from "./Chakra";
+
+async function AsyncComponent() {
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  return null;
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<Spinner />}>
+      <AsyncComponent />
+      <Button>Hello Chakra UI!</Button>
+    </Suspense>
+  );
+}

--- a/examples/chakra-ui/package.json
+++ b/examples/chakra-ui/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@lazarv/react-server-example-chakra-ui",
+  "private": true,
+  "description": "@lazarv/react-server Chakra UI example application",
+  "scripts": {
+    "dev": "react-server",
+    "build": "react-server build",
+    "start": "react-server start"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@lazarv/react-server": "workspace:^",
+    "@lazarv/react-server-router": "workspace:^",
+    "@chakra-ui/react": "^2.8.2",
+    "@emotion/react": "^11.13.3",
+    "@emotion/styled": "^11.13.0",
+    "framer-motion": "^11.5.4"
+  }
+}

--- a/examples/chakra-ui/react-server.config.mjs
+++ b/examples/chakra-ui/react-server.config.mjs
@@ -8,11 +8,12 @@ export default {
     include: ["**/layout.jsx"],
   },
   build: {
+    chunkSizeWarningLimit: 1000,
     rollupOptions: {
       output: {
         manualChunks(id) {
-          if (id.includes("@mui/")) {
-            return "@mui/material";
+          if (id.includes("@chakra-ui/react")) {
+            return "@chakra-ui/react";
           }
         },
       },

--- a/packages/react-server/lib/build/client.mjs
+++ b/packages/react-server/lib/build/client.mjs
@@ -2,7 +2,6 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
-import { createHash } from "node:crypto";
 
 import replace from "@rollup/plugin-replace";
 import colors from "picocolors";

--- a/packages/react-server/lib/dev/create-logger.mjs
+++ b/packages/react-server/lib/dev/create-logger.mjs
@@ -30,19 +30,16 @@ export default function createLogger(level = "info", options) {
     ...["info", "warn", "warnOnce"].reduce((newLogger, command) => {
       newLogger[command] = (...args) => {
         const [msg, ...rest] = args;
-        const lowerCaseMsg = msg.toLowerCase();
-        // omit vite warnings on prop-types and react-is
+        const options = rest?.[rest?.length - 1];
+        // omit vite warnings on possible dep optimizer incompatibility
         if (
-          lowerCaseMsg.includes("warning: rewrote prop-types") ||
-          lowerCaseMsg.includes("warning: rewrote react-is") ||
-          (lowerCaseMsg.includes("cannot optimize dependency:") &&
-            lowerCaseMsg.includes("prop-types")) ||
-          (lowerCaseMsg.includes("cannot optimize dependency:") &&
-            lowerCaseMsg.includes("react-is"))
+          command === "warn" &&
+          msg.includes(
+            "dependency might be incompatible with the dep optimizer"
+          )
         ) {
           return;
         }
-        const options = rest?.[rest?.length - 1];
         logger[command](
           repeatMessage(
             typeof msg !== "string"

--- a/packages/react-server/lib/plugins/asset.mjs
+++ b/packages/react-server/lib/plugins/asset.mjs
@@ -1,0 +1,15 @@
+import * as sys from "../sys.mjs";
+
+const cwd = sys.cwd();
+
+export default function asset() {
+  return {
+    name: "react-server:asset",
+    transform(code) {
+      if (code.startsWith(`export default "/@fs${cwd}`)) {
+        return code.replace(`export default "/@fs${cwd}`, `export default "`);
+      }
+      return null;
+    },
+  };
+}

--- a/packages/react-server/lib/plugins/optimize-deps.mjs
+++ b/packages/react-server/lib/plugins/optimize-deps.mjs
@@ -1,0 +1,50 @@
+import { moduleAliases } from "../loader/module-alias.mjs";
+import { applyAlias } from "../loader/utils.mjs";
+import { bareImportRE, isModule, tryStat } from "../utils/module.mjs";
+
+const alias = moduleAliases();
+
+export default function optimizeDeps() {
+  return {
+    name: "react-server:optimize-deps",
+    enforce: "pre",
+    async resolveId(specifier, importer, resolveOptions) {
+      try {
+        const resolved = await this.resolve(specifier, importer, {
+          ...resolveOptions,
+          skipSelf: true,
+          custom: { ...resolveOptions.custom, "vite:pre-alias": true },
+        });
+        const path = resolved?.id?.split("?")[0];
+        if (
+          this.environment.name === "client" &&
+          !this.environment.depsOptimizer.isOptimizedDepFile(specifier) &&
+          path &&
+          /[cm]?js$/.test(path) &&
+          bareImportRE.test(specifier) &&
+          applyAlias(alias, specifier) === specifier &&
+          !isModule(path) &&
+          tryStat(path)?.isFile()
+        ) {
+          try {
+            const optimizedInfo =
+              this.environment.depsOptimizer.registerMissingImport(
+                specifier,
+                path
+              );
+            return {
+              id: this.environment.depsOptimizer.getOptimizedDepId(
+                optimizedInfo
+              ),
+            };
+          } catch {
+            // ignore
+          }
+        }
+        return resolved;
+      } catch {
+        // ignore
+      }
+    },
+  };
+}

--- a/packages/react-server/lib/plugins/root-module.mjs
+++ b/packages/react-server/lib/plugins/root-module.mjs
@@ -1,0 +1,59 @@
+import { createRequire } from "node:module";
+
+import * as sys from "../sys.mjs";
+
+const __require = createRequire(import.meta.url);
+const cwd = sys.cwd();
+
+export default function rootModule(root) {
+  return {
+    name: "react-server:root-module",
+    transform(code, id) {
+      if (!root || root?.startsWith("virtual:")) return null;
+      const [module, name] = root.split("#");
+      const rootModule = __require.resolve(module, { paths: [cwd] });
+
+      if (id === rootModule) {
+        const ast = this.parse(code, { sourceType: "module" });
+
+        const defaultExport = ast.body.find(
+          (node) => node.type === "ExportDefaultDeclaration"
+        );
+        const namedExports = ast.body
+          .filter(
+            (node) => node.type === "ExportNamedDeclaration" && node.declaration
+          )
+          .map((node) => node.declaration.id.name);
+        const allExports = ast.body
+          .filter(
+            (node) =>
+              node.type === "ExportNamedDeclaration" &&
+              node.specifiers.length > 0
+          )
+          .flatMap((node) => node.specifiers)
+          .map((node) => node.exported.name);
+
+        const rootName = name ?? "default";
+        if (
+          (rootName === "default" &&
+            !defaultExport &&
+            !allExports?.find((name) => name === "default")) ||
+          (rootName !== "default" &&
+            !namedExports.find((name) => name === rootName) &&
+            !allExports?.find((name) => name === rootName))
+        ) {
+          throw new Error(
+            `Module "${rootModule}" does not export "${rootName}"`
+          );
+        }
+
+        if (name && name !== "default") {
+          return {
+            code: `${code}\nexport { ${name} as default };`,
+            map: null,
+          };
+        }
+      }
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,27 @@ importers:
         specifier: ^3.4.3
         version: 3.4.4(ts-node@10.9.2(@swc/core@1.6.6(@swc/helpers@0.5.5))(@types/node@20.14.9)(typescript@5.5.2))
 
+  examples/chakra-ui:
+    dependencies:
+      '@chakra-ui/react':
+        specifier: ^2.8.2
+        version: 2.8.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@emotion/react':
+        specifier: ^11.13.3
+        version: 11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731)
+      '@emotion/styled':
+        specifier: ^11.13.0
+        version: 11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731)
+      '@lazarv/react-server':
+        specifier: workspace:^
+        version: link:../../packages/react-server
+      '@lazarv/react-server-router':
+        specifier: workspace:^
+        version: link:../../packages/react-server-router
+      framer-motion:
+        specifier: ^11.5.4
+        version: 11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+
   examples/express:
     dependencies:
       '@lazarv/react-server':
@@ -1002,6 +1023,479 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@chakra-ui/accordion@2.3.1':
+    resolution: {integrity: sha512-FSXRm8iClFyU+gVaXisOSEw0/4Q+qZbFRiuhIAkVU6Boj0FxAMrlo9a8AV5TuF77rgaHytCdHk0Ng+cyUijrag==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      framer-motion: '>=4.0.0'
+      react: '>=18'
+
+  '@chakra-ui/alert@2.2.2':
+    resolution: {integrity: sha512-jHg4LYMRNOJH830ViLuicjb3F+v6iriE/2G5T+Sd0Hna04nukNJ1MxUmBPE+vI22me2dIflfelu2v9wdB6Pojw==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/anatomy@2.2.2':
+    resolution: {integrity: sha512-MV6D4VLRIHr4PkW4zMyqfrNS1mPlCTiCXwvYGtDFQYr+xHFfonhAuf9WjsSc0nyp2m0OdkSLnzmVKkZFLo25Tg==}
+
+  '@chakra-ui/avatar@2.3.0':
+    resolution: {integrity: sha512-8gKSyLfygnaotbJbDMHDiJoF38OHXUYVme4gGxZ1fLnQEdPVEaIWfH+NndIjOM0z8S+YEFnT9KyGMUtvPrBk3g==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/breadcrumb@2.2.0':
+    resolution: {integrity: sha512-4cWCG24flYBxjruRi4RJREWTGF74L/KzI2CognAW/d/zWR0CjiScuJhf37Am3LFbCySP6WSoyBOtTIoTA4yLEA==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/breakpoint-utils@2.0.8':
+    resolution: {integrity: sha512-Pq32MlEX9fwb5j5xx8s18zJMARNHlQZH2VH1RZgfgRDpp7DcEgtRW5AInfN5CfqdHLO1dGxA7I3MqEuL5JnIsA==}
+
+  '@chakra-ui/button@2.1.0':
+    resolution: {integrity: sha512-95CplwlRKmmUXkdEp/21VkEWgnwcx2TOBG6NfYlsuLBDHSLlo5FKIiE2oSi4zXc4TLcopGcWPNcm/NDaSC5pvA==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/card@2.2.0':
+    resolution: {integrity: sha512-xUB/k5MURj4CtPAhdSoXZidUbm8j3hci9vnc+eZJVDqhDOShNlD6QeniQNRPRys4lWAQLCbFcrwL29C8naDi6g==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/checkbox@2.3.2':
+    resolution: {integrity: sha512-85g38JIXMEv6M+AcyIGLh7igNtfpAN6KGQFYxY9tBj0eWvWk4NKQxvqqyVta0bSAyIl1rixNIIezNpNWk2iO4g==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/clickable@2.1.0':
+    resolution: {integrity: sha512-flRA/ClPUGPYabu+/GLREZVZr9j2uyyazCAUHAdrTUEdDYCr31SVGhgh7dgKdtq23bOvAQJpIJjw/0Bs0WvbXw==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/close-button@2.1.1':
+    resolution: {integrity: sha512-gnpENKOanKexswSVpVz7ojZEALl2x5qjLYNqSQGbxz+aP9sOXPfUS56ebyBrre7T7exuWGiFeRwnM0oVeGPaiw==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/color-mode@2.2.0':
+    resolution: {integrity: sha512-niTEA8PALtMWRI9wJ4LL0CSBDo8NBfLNp4GD6/0hstcm3IlbBHTVKxN6HwSaoNYfphDQLxCjT4yG+0BJA5tFpg==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/control-box@2.1.0':
+    resolution: {integrity: sha512-gVrRDyXFdMd8E7rulL0SKeoljkLQiPITFnsyMO8EFHNZ+AHt5wK4LIguYVEq88APqAGZGfHFWXr79RYrNiE3Mg==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/counter@2.1.0':
+    resolution: {integrity: sha512-s6hZAEcWT5zzjNz2JIWUBzRubo9la/oof1W7EKZVVfPYHERnl5e16FmBC79Yfq8p09LQ+aqFKm/etYoJMMgghw==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/css-reset@2.3.0':
+    resolution: {integrity: sha512-cQwwBy5O0jzvl0K7PLTLgp8ijqLPKyuEMiDXwYzl95seD3AoeuoCLyzZcJtVqaUZ573PiBdAbY/IlZcwDOItWg==}
+    peerDependencies:
+      '@emotion/react': '>=10.0.35'
+      react: '>=18'
+
+  '@chakra-ui/descendant@3.1.0':
+    resolution: {integrity: sha512-VxCIAir08g5w27klLyi7PVo8BxhW4tgU/lxQyujkmi4zx7hT9ZdrcQLAted/dAa+aSIZ14S1oV0Q9lGjsAdxUQ==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/dom-utils@2.1.0':
+    resolution: {integrity: sha512-ZmF2qRa1QZ0CMLU8M1zCfmw29DmPNtfjR9iTo74U5FPr3i1aoAh7fbJ4qAlZ197Xw9eAW28tvzQuoVWeL5C7fQ==}
+
+  '@chakra-ui/editable@3.1.0':
+    resolution: {integrity: sha512-j2JLrUL9wgg4YA6jLlbU88370eCRyor7DZQD9lzpY95tSOXpTljeg3uF9eOmDnCs6fxp3zDWIfkgMm/ExhcGTg==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/event-utils@2.0.8':
+    resolution: {integrity: sha512-IGM/yGUHS+8TOQrZGpAKOJl/xGBrmRYJrmbHfUE7zrG3PpQyXvbLDP1M+RggkCFVgHlJi2wpYIf0QtQlU0XZfw==}
+
+  '@chakra-ui/focus-lock@2.1.0':
+    resolution: {integrity: sha512-EmGx4PhWGjm4dpjRqM4Aa+rCWBxP+Rq8Uc/nAVnD4YVqkEhBkrPTpui2lnjsuxqNaZ24fIAZ10cF1hlpemte/w==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/form-control@2.2.0':
+    resolution: {integrity: sha512-wehLC1t4fafCVJ2RvJQT2jyqsAwX7KymmiGqBu7nQoQz8ApTkGABWpo/QwDh3F/dBLrouHDoOvGmYTqft3Mirw==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/hooks@2.2.1':
+    resolution: {integrity: sha512-RQbTnzl6b1tBjbDPf9zGRo9rf/pQMholsOudTxjy4i9GfTfz6kgp5ValGjQm2z7ng6Z31N1cnjZ1AlSzQ//ZfQ==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/icon@3.2.0':
+    resolution: {integrity: sha512-xxjGLvlX2Ys4H0iHrI16t74rG9EBcpFvJ3Y3B7KMQTrnW34Kf7Da/UC8J67Gtx85mTHW020ml85SVPKORWNNKQ==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/image@2.1.0':
+    resolution: {integrity: sha512-bskumBYKLiLMySIWDGcz0+D9Th0jPvmX6xnRMs4o92tT3Od/bW26lahmV2a2Op2ItXeCmRMY+XxJH5Gy1i46VA==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/input@2.1.2':
+    resolution: {integrity: sha512-GiBbb3EqAA8Ph43yGa6Mc+kUPjh4Spmxp1Pkelr8qtudpc3p2PJOOebLpd90mcqw8UePPa+l6YhhPtp6o0irhw==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/layout@2.3.1':
+    resolution: {integrity: sha512-nXuZ6WRbq0WdgnRgLw+QuxWAHuhDtVX8ElWqcTK+cSMFg/52eVP47czYBE5F35YhnoW2XBwfNoNgZ7+e8Z01Rg==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/lazy-utils@2.0.5':
+    resolution: {integrity: sha512-UULqw7FBvcckQk2n3iPO56TMJvDsNv0FKZI6PlUNJVaGsPbsYxK/8IQ60vZgaTVPtVcjY6BE+y6zg8u9HOqpyg==}
+
+  '@chakra-ui/live-region@2.1.0':
+    resolution: {integrity: sha512-ZOxFXwtaLIsXjqnszYYrVuswBhnIHHP+XIgK1vC6DePKtyK590Wg+0J0slDwThUAd4MSSIUa/nNX84x1GMphWw==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/media-query@3.3.0':
+    resolution: {integrity: sha512-IsTGgFLoICVoPRp9ykOgqmdMotJG0CnPsKvGQeSFOB/dZfIujdVb14TYxDU4+MURXry1MhJ7LzZhv+Ml7cr8/g==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/menu@2.2.1':
+    resolution: {integrity: sha512-lJS7XEObzJxsOwWQh7yfG4H8FzFPRP5hVPN/CL+JzytEINCSBvsCDHrYPQGp7jzpCi8vnTqQQGQe0f8dwnXd2g==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      framer-motion: '>=4.0.0'
+      react: '>=18'
+
+  '@chakra-ui/modal@2.3.1':
+    resolution: {integrity: sha512-TQv1ZaiJMZN+rR9DK0snx/OPwmtaGH1HbZtlYt4W4s6CzyK541fxLRTjIXfEzIGpvNW+b6VFuFjbcR78p4DEoQ==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      framer-motion: '>=4.0.0'
+      react: '>=18'
+      react-dom: '>=18'
+
+  '@chakra-ui/number-input@2.1.2':
+    resolution: {integrity: sha512-pfOdX02sqUN0qC2ysuvgVDiws7xZ20XDIlcNhva55Jgm095xjm8eVdIBfNm3SFbSUNxyXvLTW/YQanX74tKmuA==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/number-utils@2.0.7':
+    resolution: {integrity: sha512-yOGxBjXNvLTBvQyhMDqGU0Oj26s91mbAlqKHiuw737AXHt0aPllOthVUqQMeaYLwLCjGMg0jtI7JReRzyi94Dg==}
+
+  '@chakra-ui/object-utils@2.1.0':
+    resolution: {integrity: sha512-tgIZOgLHaoti5PYGPTwK3t/cqtcycW0owaiOXoZOcpwwX/vlVb+H1jFsQyWiiwQVPt9RkoSLtxzXamx+aHH+bQ==}
+
+  '@chakra-ui/pin-input@2.1.0':
+    resolution: {integrity: sha512-x4vBqLStDxJFMt+jdAHHS8jbh294O53CPQJoL4g228P513rHylV/uPscYUHrVJXRxsHfRztQO9k45jjTYaPRMw==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/popover@2.2.1':
+    resolution: {integrity: sha512-K+2ai2dD0ljvJnlrzesCDT9mNzLifE3noGKZ3QwLqd/K34Ym1W/0aL1ERSynrcG78NKoXS54SdEzkhCZ4Gn/Zg==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      framer-motion: '>=4.0.0'
+      react: '>=18'
+
+  '@chakra-ui/popper@3.1.0':
+    resolution: {integrity: sha512-ciDdpdYbeFG7og6/6J8lkTFxsSvwTdMLFkpVylAF6VNC22jssiWfquj2eyD4rJnzkRFPvIWJq8hvbfhsm+AjSg==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/portal@2.1.0':
+    resolution: {integrity: sha512-9q9KWf6SArEcIq1gGofNcFPSWEyl+MfJjEUg/un1SMlQjaROOh3zYr+6JAwvcORiX7tyHosnmWC3d3wI2aPSQg==}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  '@chakra-ui/progress@2.2.0':
+    resolution: {integrity: sha512-qUXuKbuhN60EzDD9mHR7B67D7p/ZqNS2Aze4Pbl1qGGZfulPW0PY8Rof32qDtttDQBkzQIzFGE8d9QpAemToIQ==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/provider@2.4.2':
+    resolution: {integrity: sha512-w0Tef5ZCJK1mlJorcSjItCSbyvVuqpvyWdxZiVQmE6fvSJR83wZof42ux0+sfWD+I7rHSfj+f9nzhNaEWClysw==}
+    peerDependencies:
+      '@emotion/react': ^11.0.0
+      '@emotion/styled': ^11.0.0
+      react: '>=18'
+      react-dom: '>=18'
+
+  '@chakra-ui/radio@2.1.2':
+    resolution: {integrity: sha512-n10M46wJrMGbonaghvSRnZ9ToTv/q76Szz284gv4QUWvyljQACcGrXIONUnQ3BIwbOfkRqSk7Xl/JgZtVfll+w==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/react-children-utils@2.0.6':
+    resolution: {integrity: sha512-QVR2RC7QsOsbWwEnq9YduhpqSFnZGvjjGREV8ygKi8ADhXh93C8azLECCUVgRJF2Wc+So1fgxmjLcbZfY2VmBA==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-context@2.1.0':
+    resolution: {integrity: sha512-iahyStvzQ4AOwKwdPReLGfDesGG+vWJfEsn0X/NoGph/SkN+HXtv2sCfYFFR9k7bb+Kvc6YfpLlSuLvKMHi2+w==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-env@3.1.0':
+    resolution: {integrity: sha512-Vr96GV2LNBth3+IKzr/rq1IcnkXv+MLmwjQH6C8BRtn3sNskgDFD5vLkVXcEhagzZMCh8FR3V/bzZPojBOyNhw==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-types@2.0.7':
+    resolution: {integrity: sha512-12zv2qIZ8EHwiytggtGvo4iLT0APris7T0qaAWqzpUGS0cdUtR8W+V1BJ5Ocq+7tA6dzQ/7+w5hmXih61TuhWQ==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-use-animation-state@2.1.0':
+    resolution: {integrity: sha512-CFZkQU3gmDBwhqy0vC1ryf90BVHxVN8cTLpSyCpdmExUEtSEInSCGMydj2fvn7QXsz/za8JNdO2xxgJwxpLMtg==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-use-callback-ref@2.1.0':
+    resolution: {integrity: sha512-efnJrBtGDa4YaxDzDE90EnKD3Vkh5a1t3w7PhnRQmsphLy3g2UieasoKTlT2Hn118TwDjIv5ZjHJW6HbzXA9wQ==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-use-controllable-state@2.1.0':
+    resolution: {integrity: sha512-QR/8fKNokxZUs4PfxjXuwl0fj/d71WPrmLJvEpCTkHjnzu7LnYvzoe2wB867IdooQJL0G1zBxl0Dq+6W1P3jpg==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-use-disclosure@2.1.0':
+    resolution: {integrity: sha512-Ax4pmxA9LBGMyEZJhhUZobg9C0t3qFE4jVF1tGBsrLDcdBeLR9fwOogIPY9Hf0/wqSlAryAimICbr5hkpa5GSw==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-use-event-listener@2.1.0':
+    resolution: {integrity: sha512-U5greryDLS8ISP69DKDsYcsXRtAdnTQT+jjIlRYZ49K/XhUR/AqVZCK5BkR1spTDmO9H8SPhgeNKI70ODuDU/Q==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-use-focus-effect@2.1.0':
+    resolution: {integrity: sha512-xzVboNy7J64xveLcxTIJ3jv+lUJKDwRM7Szwn9tNzUIPD94O3qwjV7DDCUzN2490nSYDF4OBMt/wuDBtaR3kUQ==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-use-focus-on-pointer-down@2.1.0':
+    resolution: {integrity: sha512-2jzrUZ+aiCG/cfanrolsnSMDykCAbv9EK/4iUyZno6BYb3vziucmvgKuoXbMPAzWNtwUwtuMhkby8rc61Ue+Lg==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-use-interval@2.1.0':
+    resolution: {integrity: sha512-8iWj+I/+A0J08pgEXP1J1flcvhLBHkk0ln7ZvGIyXiEyM6XagOTJpwNhiu+Bmk59t3HoV/VyvyJTa+44sEApuw==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-use-latest-ref@2.1.0':
+    resolution: {integrity: sha512-m0kxuIYqoYB0va9Z2aW4xP/5b7BzlDeWwyXCH6QpT2PpW3/281L3hLCm1G0eOUcdVlayqrQqOeD6Mglq+5/xoQ==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-use-merge-refs@2.1.0':
+    resolution: {integrity: sha512-lERa6AWF1cjEtWSGjxWTaSMvneccnAVH4V4ozh8SYiN9fSPZLlSG3kNxfNzdFvMEhM7dnP60vynF7WjGdTgQbQ==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-use-outside-click@2.2.0':
+    resolution: {integrity: sha512-PNX+s/JEaMneijbgAM4iFL+f3m1ga9+6QK0E5Yh4s8KZJQ/bLwZzdhMz8J/+mL+XEXQ5J0N8ivZN28B82N1kNw==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-use-pan-event@2.1.0':
+    resolution: {integrity: sha512-xmL2qOHiXqfcj0q7ZK5s9UjTh4Gz0/gL9jcWPA6GVf+A0Od5imEDa/Vz+533yQKWiNSm1QGrIj0eJAokc7O4fg==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-use-previous@2.1.0':
+    resolution: {integrity: sha512-pjxGwue1hX8AFcmjZ2XfrQtIJgqbTF3Qs1Dy3d1krC77dEsiCUbQ9GzOBfDc8pfd60DrB5N2tg5JyHbypqh0Sg==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-use-safe-layout-effect@2.1.0':
+    resolution: {integrity: sha512-Knbrrx/bcPwVS1TorFdzrK/zWA8yuU/eaXDkNj24IrKoRlQrSBFarcgAEzlCHtzuhufP3OULPkELTzz91b0tCw==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-use-size@2.1.0':
+    resolution: {integrity: sha512-tbLqrQhbnqOjzTaMlYytp7wY8BW1JpL78iG7Ru1DlV4EWGiAmXFGvtnEt9HftU0NJ0aJyjgymkxfVGI55/1Z4A==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-use-timeout@2.1.0':
+    resolution: {integrity: sha512-cFN0sobKMM9hXUhyCofx3/Mjlzah6ADaEl/AXl5Y+GawB5rgedgAcu2ErAgarEkwvsKdP6c68CKjQ9dmTQlJxQ==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-use-update-effect@2.1.0':
+    resolution: {integrity: sha512-ND4Q23tETaR2Qd3zwCKYOOS1dfssojPLJMLvUtUbW5M9uW1ejYWgGUobeAiOVfSplownG8QYMmHTP86p/v0lbA==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react-utils@2.0.12':
+    resolution: {integrity: sha512-GbSfVb283+YA3kA8w8xWmzbjNWk14uhNpntnipHCftBibl0lxtQ9YqMFQLwuFOO0U2gYVocszqqDWX+XNKq9hw==}
+    peerDependencies:
+      react: '>=18'
+
+  '@chakra-ui/react@2.8.2':
+    resolution: {integrity: sha512-Hn0moyxxyCDKuR9ywYpqgX8dvjqwu9ArwpIb9wHNYjnODETjLwazgNIliCVBRcJvysGRiV51U2/JtJVrpeCjUQ==}
+    peerDependencies:
+      '@emotion/react': ^11.0.0
+      '@emotion/styled': ^11.0.0
+      framer-motion: '>=4.0.0'
+      react: '>=18'
+      react-dom: '>=18'
+
+  '@chakra-ui/select@2.1.2':
+    resolution: {integrity: sha512-ZwCb7LqKCVLJhru3DXvKXpZ7Pbu1TDZ7N0PdQ0Zj1oyVLJyrpef1u9HR5u0amOpqcH++Ugt0f5JSmirjNlctjA==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/shared-utils@2.0.5':
+    resolution: {integrity: sha512-4/Wur0FqDov7Y0nCXl7HbHzCg4aq86h+SXdoUeuCMD3dSj7dpsVnStLYhng1vxvlbUnLpdF4oz5Myt3i/a7N3Q==}
+
+  '@chakra-ui/skeleton@2.1.0':
+    resolution: {integrity: sha512-JNRuMPpdZGd6zFVKjVQ0iusu3tXAdI29n4ZENYwAJEMf/fN0l12sVeirOxkJ7oEL0yOx2AgEYFSKdbcAgfUsAQ==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/skip-nav@2.1.0':
+    resolution: {integrity: sha512-Hk+FG+vadBSH0/7hwp9LJnLjkO0RPGnx7gBJWI4/SpoJf3e4tZlWYtwGj0toYY4aGKl93jVghuwGbDBEMoHDug==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/slider@2.1.0':
+    resolution: {integrity: sha512-lUOBcLMCnFZiA/s2NONXhELJh6sY5WtbRykPtclGfynqqOo47lwWJx+VP7xaeuhDOPcWSSecWc9Y1BfPOCz9cQ==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/spinner@2.1.0':
+    resolution: {integrity: sha512-hczbnoXt+MMv/d3gE+hjQhmkzLiKuoTo42YhUG7Bs9OSv2lg1fZHW1fGNRFP3wTi6OIbD044U1P9HK+AOgFH3g==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/stat@2.1.1':
+    resolution: {integrity: sha512-LDn0d/LXQNbAn2KaR3F1zivsZCewY4Jsy1qShmfBMKwn6rI8yVlbvu6SiA3OpHS0FhxbsZxQI6HefEoIgtqY6Q==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/stepper@2.3.1':
+    resolution: {integrity: sha512-ky77lZbW60zYkSXhYz7kbItUpAQfEdycT0Q4bkHLxfqbuiGMf8OmgZOQkOB9uM4v0zPwy2HXhe0vq4Dd0xa55Q==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/styled-system@2.9.2':
+    resolution: {integrity: sha512-To/Z92oHpIE+4nk11uVMWqo2GGRS86coeMmjxtpnErmWRdLcp1WVCVRAvn+ZwpLiNR+reWFr2FFqJRsREuZdAg==}
+
+  '@chakra-ui/switch@2.1.2':
+    resolution: {integrity: sha512-pgmi/CC+E1v31FcnQhsSGjJnOE2OcND4cKPyTE+0F+bmGm48Q/b5UmKD9Y+CmZsrt/7V3h8KNczowupfuBfIHA==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      framer-motion: '>=4.0.0'
+      react: '>=18'
+
+  '@chakra-ui/system@2.6.2':
+    resolution: {integrity: sha512-EGtpoEjLrUu4W1fHD+a62XR+hzC5YfsWm+6lO0Kybcga3yYEij9beegO0jZgug27V+Rf7vns95VPVP6mFd/DEQ==}
+    peerDependencies:
+      '@emotion/react': ^11.0.0
+      '@emotion/styled': ^11.0.0
+      react: '>=18'
+
+  '@chakra-ui/table@2.1.0':
+    resolution: {integrity: sha512-o5OrjoHCh5uCLdiUb0Oc0vq9rIAeHSIRScc2ExTC9Qg/uVZl2ygLrjToCaKfaaKl1oQexIeAcZDKvPG8tVkHyQ==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/tabs@3.0.0':
+    resolution: {integrity: sha512-6Mlclp8L9lqXmsGWF5q5gmemZXOiOYuh0SGT/7PgJVNPz3LXREXlXg2an4MBUD8W5oTkduCX+3KTMCwRrVrDYw==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/tag@3.1.1':
+    resolution: {integrity: sha512-Bdel79Dv86Hnge2PKOU+t8H28nm/7Y3cKd4Kfk9k3lOpUh4+nkSGe58dhRzht59lEqa4N9waCgQiBdkydjvBXQ==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/textarea@2.1.2':
+    resolution: {integrity: sha512-ip7tvklVCZUb2fOHDb23qPy/Fr2mzDOGdkrpbNi50hDCiV4hFX02jdQJdi3ydHZUyVgZVBKPOJ+lT9i7sKA2wA==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+
+  '@chakra-ui/theme-tools@2.1.2':
+    resolution: {integrity: sha512-Qdj8ajF9kxY4gLrq7gA+Azp8CtFHGO9tWMN2wfF9aQNgG9AuMhPrUzMq9AMQ0MXiYcgNq/FD3eegB43nHVmXVA==}
+    peerDependencies:
+      '@chakra-ui/styled-system': '>=2.0.0'
+
+  '@chakra-ui/theme-utils@2.0.21':
+    resolution: {integrity: sha512-FjH5LJbT794r0+VSCXB3lT4aubI24bLLRWB+CuRKHijRvsOg717bRdUN/N1fEmEpFnRVrbewttWh/OQs0EWpWw==}
+
+  '@chakra-ui/theme@3.3.1':
+    resolution: {integrity: sha512-Hft/VaT8GYnItGCBbgWd75ICrIrIFrR7lVOhV/dQnqtfGqsVDlrztbSErvMkoPKt0UgAkd9/o44jmZ6X4U2nZQ==}
+    peerDependencies:
+      '@chakra-ui/styled-system': '>=2.8.0'
+
+  '@chakra-ui/toast@7.0.2':
+    resolution: {integrity: sha512-yvRP8jFKRs/YnkuE41BVTq9nB2v/KDRmje9u6dgDmE5+1bFt3bwjdf9gVbif4u5Ve7F7BGk5E093ARRVtvLvXA==}
+    peerDependencies:
+      '@chakra-ui/system': 2.6.2
+      framer-motion: '>=4.0.0'
+      react: '>=18'
+      react-dom: '>=18'
+
+  '@chakra-ui/tooltip@2.3.1':
+    resolution: {integrity: sha512-Rh39GBn/bL4kZpuEMPPRwYNnccRCL+w9OqamWHIB3Qboxs6h8cOyXfIdGxjo72lvhu1QI/a4KFqkM3St+WfC0A==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      framer-motion: '>=4.0.0'
+      react: '>=18'
+      react-dom: '>=18'
+
+  '@chakra-ui/transition@2.1.0':
+    resolution: {integrity: sha512-orkT6T/Dt+/+kVwJNy7zwJ+U2xAZ3EU7M3XCs45RBvUnZDr/u9vdmaM/3D/rOpmQJWgQBwKPJleUXrYWUagEDQ==}
+    peerDependencies:
+      framer-motion: '>=4.0.0'
+      react: '>=18'
+
+  '@chakra-ui/utils@2.0.15':
+    resolution: {integrity: sha512-El4+jL0WSaYYs+rJbuYFDbjmfCcfGDmRY95GO4xwzit6YAPZBLcR65rOEwLps+XWluZTy1xdMrusg/hW0c1aAA==}
+
+  '@chakra-ui/visually-hidden@2.2.0':
+    resolution: {integrity: sha512-KmKDg01SrQ7VbTD3+cPWf/UfpF5MSwm3v7MWi0n5t8HnnadT13MF0MJCDSXbBWnzLv1ZKJ6zlyAOeARWX+DpjQ==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -2356,6 +2850,12 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/lodash.mergewith@4.6.7':
+    resolution: {integrity: sha512-3m+lkO5CLRRYU0fhGRp7zbsGi6+BZj0uTVSwvcKU+nSlhjA9/QRNfuSGnD2mX6hQA7ZbmcCkzk5h4ZYGOtk14A==}
+
+  '@types/lodash@4.17.7':
+    resolution: {integrity: sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -2673,6 +3173,15 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
+  '@zag-js/dom-query@0.16.0':
+    resolution: {integrity: sha512-Oqhd6+biWyKnhKwFFuZrrf6lxBz2tX2pRQe6grUnYwO6HJ8BcbqZomy2lpOdr+3itlaUqx+Ywj5E5ZZDr/LBfQ==}
+
+  '@zag-js/element-size@0.10.5':
+    resolution: {integrity: sha512-uQre5IidULANvVkNOBQ1tfgwTQcGl4hliPSe69Fct1VfYb2Fd0jdAcGzqQgPhfrXFpR62MxLPB7erxJ/ngtL8w==}
+
+  '@zag-js/focus-visible@0.16.0':
+    resolution: {integrity: sha512-a7U/HSopvQbrDU4GLerpqiMcHKEkQkNPeDZJWz38cw/6Upunh41GjHetq5TB84hxyCaDzJ6q2nEdNoBQfC0FKA==}
+
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
     hasBin: true
@@ -2811,6 +3320,10 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-hidden@1.2.4:
+    resolution: {integrity: sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==}
+    engines: {node: '>=10'}
 
   aria-query@5.1.3:
     resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
@@ -3187,6 +3700,9 @@ packages:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
     hasBin: true
 
+  color2k@2.0.3:
+    resolution: {integrity: sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog==}
+
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
@@ -3217,6 +3733,9 @@ packages:
 
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
+
+  compute-scroll-into-view@3.0.3:
+    resolution: {integrity: sha512-nadqwNxghAGTamwIqQSG433W6OADZx2vCo3UXHNrzTRHK/htu+7+L0zhjEoaeaQVNAi3YgqWDv8+tzf0hRfR+A==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -3283,6 +3802,9 @@ packages:
   copy-anything@2.0.6:
     resolution: {integrity: sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==}
 
+  copy-to-clipboard@3.3.3:
+    resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -3335,6 +3857,9 @@ packages:
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
+
+  css-box-model@1.2.1:
+    resolution: {integrity: sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -3910,6 +4435,10 @@ packages:
   flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
 
+  focus-lock@1.3.5:
+    resolution: {integrity: sha512-QFaHbhv9WPUeLYBDe/PAuLKJ4Dd9OPvKs9xZBr3yLXnUrDNaVXKu2baDBXe3naPY30hgHYSsf2JW4jzas2mDEQ==}
+    engines: {node: '>=10'}
+
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
 
@@ -3941,6 +4470,23 @@ packages:
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
+
+  framer-motion@11.5.4:
+    resolution: {integrity: sha512-E+tb3/G6SO69POkdJT+3EpdMuhmtCh9EWuK4I1DnIC23L7tFPrl8vxP+LSovwaw6uUr73rUbpb4FgK011wbRJQ==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  framesync@6.1.2:
+    resolution: {integrity: sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==}
 
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -5818,6 +6364,11 @@ packages:
       react: 0.0.0-experimental-58af67a8f8-20240628
       react-dom: 0.0.0-experimental-58af67a8f8-20240628
 
+  react-clientside-effect@1.2.6:
+    resolution: {integrity: sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==}
+    peerDependencies:
+      react: ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+
   react-dom@0.0.0-experimental-58af67a8f8-20240628:
     resolution: {integrity: sha512-b6SvDT4u/nCnOYd8LX+c0S7dH0hScrk/X3mDWjCeNo2GBHrZhgUCmuVunCHN8aqPylVfVtIotoByBVeIrm2aMg==}
     peerDependencies:
@@ -5827,6 +6378,18 @@ packages:
     resolution: {integrity: sha512-jspKji5vQTTlFY7zFGh0VB+rZV+5FweCQkYxtLoPZvc5ZH6vEf1n8d+4h9YqNqF8nnhFkcHO8XLtKTtTyVGSXA==}
     peerDependencies:
       react: 19.0.0-rc-3208e73e-20240730
+
+  react-fast-compare@3.2.2:
+    resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
+
+  react-focus-lock@2.13.2:
+    resolution: {integrity: sha512-T/7bsofxYqnod2xadvuwjGKHOoL5GH7/EIPI5UyEvaU/c2CcphvGI371opFtuY/SYdbMsNiuF4HsHQ50nA/TKQ==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -6593,6 +7156,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toggle-selection@1.0.6:
+    resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
@@ -6674,6 +7240,9 @@ packages:
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
+
+  tslib@2.4.0:
+    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
 
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
@@ -7579,6 +8148,707 @@ snapshots:
       to-fast-properties: 2.0.0
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@chakra-ui/accordion@2.3.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/descendant': 3.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/icon': 3.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/transition': 2.1.0(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      framer-motion: 11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/alert@2.2.2(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/icon': 3.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/spinner': 2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/anatomy@2.2.2': {}
+
+  '@chakra-ui/avatar@2.3.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/image': 2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-children-utils': 2.0.6(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/breadcrumb@2.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/react-children-utils': 2.0.6(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/breakpoint-utils@2.0.8':
+    dependencies:
+      '@chakra-ui/shared-utils': 2.0.5
+
+  '@chakra-ui/button@2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/spinner': 2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/card@2.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/checkbox@2.3.2(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/form-control': 2.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-types': 2.0.7(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/visually-hidden': 2.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@zag-js/focus-visible': 0.16.0
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/clickable@2.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/close-button@2.1.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/icon': 3.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/color-mode@2.2.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/control-box@2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/counter@2.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/number-utils': 2.0.7
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/css-reset@2.3.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@emotion/react': 11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/descendant@3.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/dom-utils@2.1.0': {}
+
+  '@chakra-ui/editable@3.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-types': 2.0.7(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-focus-on-pointer-down': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/event-utils@2.0.8': {}
+
+  '@chakra-ui/focus-lock@2.1.0(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/dom-utils': 2.1.0
+      react: 19.0.0-rc-a7d1240c-20240731
+      react-focus-lock: 2.13.2(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@chakra-ui/form-control@2.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/icon': 3.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-types': 2.0.7(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/hooks@2.2.1(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/react-utils': 2.0.12(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/utils': 2.0.15
+      compute-scroll-into-view: 3.0.3
+      copy-to-clipboard: 3.3.3
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/icon@3.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/image@2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/input@2.1.2(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/form-control': 2.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/object-utils': 2.1.0
+      '@chakra-ui/react-children-utils': 2.0.6(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/layout@2.3.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/breakpoint-utils': 2.0.8
+      '@chakra-ui/icon': 3.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/object-utils': 2.1.0
+      '@chakra-ui/react-children-utils': 2.0.6(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/lazy-utils@2.0.5': {}
+
+  '@chakra-ui/live-region@2.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/media-query@3.3.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/breakpoint-utils': 2.0.8
+      '@chakra-ui/react-env': 3.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/menu@2.2.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/clickable': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/descendant': 3.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/lazy-utils': 2.0.5
+      '@chakra-ui/popper': 3.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-children-utils': 2.0.6(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-animation-state': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-disclosure': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-focus-effect': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-outside-click': 2.2.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/transition': 2.1.0(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      framer-motion: 11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/modal@2.3.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/close-button': 2.1.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/focus-lock': 2.1.0(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/portal': 2.1.0(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-types': 2.0.7(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/transition': 2.1.0(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      aria-hidden: 1.2.4
+      framer-motion: 11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+      react-dom: 19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731)
+      react-remove-scroll: 2.5.10(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@chakra-ui/number-input@2.1.2(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/counter': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/form-control': 2.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/icon': 3.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-types': 2.0.7(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-event-listener': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-interval': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/number-utils@2.0.7': {}
+
+  '@chakra-ui/object-utils@2.1.0': {}
+
+  '@chakra-ui/pin-input@2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/descendant': 3.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-children-utils': 2.0.6(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/popover@2.2.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/close-button': 2.1.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/lazy-utils': 2.0.5
+      '@chakra-ui/popper': 3.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-types': 2.0.7(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-animation-state': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-disclosure': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-focus-effect': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-focus-on-pointer-down': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      framer-motion: 11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/popper@3.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/react-types': 2.0.7(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@popperjs/core': 2.11.8
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/portal@2.1.0(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+      react-dom: 19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731)
+
+  '@chakra-ui/progress@2.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/provider@2.4.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/css-reset': 2.3.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/portal': 2.1.0(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-env': 3.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/utils': 2.0.15
+      '@emotion/react': 11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731)
+      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+      react-dom: 19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731)
+
+  '@chakra-ui/radio@2.1.2(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/form-control': 2.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-types': 2.0.7(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@zag-js/focus-visible': 0.16.0
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-children-utils@2.0.6(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-context@2.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-env@3.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-types@2.0.7(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-use-animation-state@2.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/dom-utils': 2.1.0
+      '@chakra-ui/react-use-event-listener': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-use-callback-ref@2.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-use-controllable-state@2.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-use-disclosure@2.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-use-event-listener@2.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-use-focus-effect@2.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/dom-utils': 2.1.0
+      '@chakra-ui/react-use-event-listener': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-use-focus-on-pointer-down@2.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/react-use-event-listener': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-use-interval@2.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-use-latest-ref@2.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-use-merge-refs@2.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-use-outside-click@2.2.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-use-pan-event@2.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/event-utils': 2.0.8
+      '@chakra-ui/react-use-latest-ref': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      framesync: 6.1.2
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-use-previous@2.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-use-safe-layout-effect@2.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-use-size@2.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@zag-js/element-size': 0.10.5
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-use-timeout@2.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-use-update-effect@2.1.0(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react-utils@2.0.12(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/utils': 2.0.15
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/react@2.8.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/accordion': 2.3.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/alert': 2.2.2(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/avatar': 2.3.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/breadcrumb': 2.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/button': 2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/card': 2.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/checkbox': 2.3.2(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/close-button': 2.1.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/control-box': 2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/counter': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/css-reset': 2.3.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/editable': 3.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/focus-lock': 2.1.0(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/form-control': 2.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/hooks': 2.2.1(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/icon': 3.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/image': 2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/input': 2.1.2(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/layout': 2.3.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/live-region': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/media-query': 3.3.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/menu': 2.2.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/modal': 2.3.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/number-input': 2.1.2(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/pin-input': 2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/popover': 2.2.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/popper': 3.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/portal': 2.1.0(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/progress': 2.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/provider': 2.4.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/radio': 2.1.2(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-env': 3.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/select': 2.1.2(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/skeleton': 2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/skip-nav': 2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/slider': 2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/spinner': 2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/stat': 2.1.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/stepper': 2.3.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/styled-system': 2.9.2
+      '@chakra-ui/switch': 2.1.2(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/table': 2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/tabs': 3.0.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/tag': 3.1.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/textarea': 2.1.2(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/theme': 3.3.1(@chakra-ui/styled-system@2.9.2)
+      '@chakra-ui/theme-utils': 2.0.21
+      '@chakra-ui/toast': 7.0.2(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/tooltip': 2.3.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/transition': 2.1.0(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/utils': 2.0.15
+      '@chakra-ui/visually-hidden': 2.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@emotion/react': 11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731)
+      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731)
+      framer-motion: 11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+      react-dom: 19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@chakra-ui/select@2.1.2(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/form-control': 2.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/shared-utils@2.0.5': {}
+
+  '@chakra-ui/skeleton@2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/media-query': 3.3.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-previous': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/skip-nav@2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/slider@2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/number-utils': 2.0.7
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-types': 2.0.7(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-latest-ref': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-pan-event': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-size': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/spinner@2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/stat@2.1.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/icon': 3.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/stepper@2.3.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/icon': 3.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/styled-system@2.9.2':
+    dependencies:
+      '@chakra-ui/shared-utils': 2.0.5
+      csstype: 3.1.3
+      lodash.mergewith: 4.6.2
+
+  '@chakra-ui/switch@2.1.2(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/checkbox': 2.3.2(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      framer-motion: 11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/color-mode': 2.2.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/object-utils': 2.1.0
+      '@chakra-ui/react-utils': 2.0.12(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/styled-system': 2.9.2
+      '@chakra-ui/theme-utils': 2.0.21
+      '@chakra-ui/utils': 2.0.15
+      '@emotion/react': 11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731)
+      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+      react-fast-compare: 3.2.2
+
+  '@chakra-ui/table@2.1.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/tabs@3.0.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/clickable': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/descendant': 3.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/lazy-utils': 2.0.5
+      '@chakra-ui/react-children-utils': 2.0.6(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/tag@3.1.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/icon': 3.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/textarea@2.1.2(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/form-control': 2.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/theme-tools@2.1.2(@chakra-ui/styled-system@2.9.2)':
+    dependencies:
+      '@chakra-ui/anatomy': 2.2.2
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/styled-system': 2.9.2
+      color2k: 2.0.3
+
+  '@chakra-ui/theme-utils@2.0.21':
+    dependencies:
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/styled-system': 2.9.2
+      '@chakra-ui/theme': 3.3.1(@chakra-ui/styled-system@2.9.2)
+      lodash.mergewith: 4.6.2
+
+  '@chakra-ui/theme@3.3.1(@chakra-ui/styled-system@2.9.2)':
+    dependencies:
+      '@chakra-ui/anatomy': 2.2.2
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/styled-system': 2.9.2
+      '@chakra-ui/theme-tools': 2.1.2(@chakra-ui/styled-system@2.9.2)
+
+  '@chakra-ui/toast@7.0.2(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/alert': 2.2.2(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/close-button': 2.1.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/portal': 2.1.0(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-context': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-timeout': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/styled-system': 2.9.2
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/theme': 3.3.1(@chakra-ui/styled-system@2.9.2)
+      framer-motion: 11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+      react-dom: 19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731)
+
+  '@chakra-ui/tooltip@2.3.1(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/dom-utils': 2.1.0
+      '@chakra-ui/popper': 3.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/portal': 2.1.0(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-types': 2.0.7(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-disclosure': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-event-listener': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.0.0-rc-a7d1240c-20240731)
+      '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      framer-motion: 11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+      react-dom: 19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731)
+
+  '@chakra-ui/transition@2.1.0(framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/shared-utils': 2.0.5
+      framer-motion: 11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
+
+  '@chakra-ui/utils@2.0.15':
+    dependencies:
+      '@types/lodash.mergewith': 4.6.7
+      css-box-model: 1.2.1
+      framesync: 6.1.2
+      lodash.mergewith: 4.6.2
+
+  '@chakra-ui/visually-hidden@2.2.0(@chakra-ui/system@2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)':
+    dependencies:
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+      react: 19.0.0-rc-a7d1240c-20240731
 
   '@colors/colors@1.5.0':
     optional: true
@@ -9032,6 +10302,12 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/lodash.mergewith@4.6.7':
+    dependencies:
+      '@types/lodash': 4.17.7
+
+  '@types/lodash@4.17.7': {}
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.2
@@ -9444,6 +10720,14 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
+  '@zag-js/dom-query@0.16.0': {}
+
+  '@zag-js/element-size@0.10.5': {}
+
+  '@zag-js/focus-visible@0.16.0':
+    dependencies:
+      '@zag-js/dom-query': 0.16.0
+
   JSONStream@1.3.5:
     dependencies:
       jsonparse: 1.3.1
@@ -9581,6 +10865,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-hidden@1.2.4:
+    dependencies:
+      tslib: 2.6.3
 
   aria-query@5.1.3:
     dependencies:
@@ -10009,6 +11297,8 @@ snapshots:
 
   color-support@1.1.3: {}
 
+  color2k@2.0.3: {}
+
   colorette@2.0.20: {}
 
   combined-stream@1.0.8:
@@ -10037,6 +11327,8 @@ snapshots:
       dot-prop: 5.3.0
 
   component-emitter@1.3.1: {}
+
+  compute-scroll-into-view@3.0.3: {}
 
   concat-map@0.0.1: {}
 
@@ -10101,6 +11393,10 @@ snapshots:
   copy-anything@2.0.6:
     dependencies:
       is-what: 3.14.1
+
+  copy-to-clipboard@3.3.3:
+    dependencies:
+      toggle-selection: 1.0.6
 
   core-util-is@1.0.3: {}
 
@@ -10181,6 +11477,10 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-box-model@1.2.1:
+    dependencies:
+      tiny-invariant: 1.3.3
 
   cssesc@3.0.0: {}
 
@@ -10950,6 +12250,10 @@ snapshots:
 
   flatted@3.3.1: {}
 
+  focus-lock@1.3.5:
+    dependencies:
+      tslib: 2.6.3
+
   for-each@0.3.3:
     dependencies:
       is-callable: 1.2.7
@@ -10993,6 +12297,18 @@ snapshots:
   forwarded@0.2.0: {}
 
   fraction.js@4.3.7: {}
+
+  framer-motion@11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731):
+    dependencies:
+      tslib: 2.6.3
+    optionalDependencies:
+      '@emotion/is-prop-valid': 1.3.0
+      react: 19.0.0-rc-a7d1240c-20240731
+      react-dom: 19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731)
+
+  framesync@6.1.2:
+    dependencies:
+      tslib: 2.4.0
 
   fresh@0.5.2: {}
 
@@ -13379,6 +14695,11 @@ snapshots:
       react: 19.0.0-rc-a7d1240c-20240731
       react-dom: 19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731)
 
+  react-clientside-effect@1.2.6(react@19.0.0-rc-a7d1240c-20240731):
+    dependencies:
+      '@babel/runtime': 7.25.6
+      react: 19.0.0-rc-a7d1240c-20240731
+
   react-dom@0.0.0-experimental-58af67a8f8-20240628(react@0.0.0-experimental-58af67a8f8-20240628):
     dependencies:
       react: 0.0.0-experimental-58af67a8f8-20240628
@@ -13388,6 +14709,20 @@ snapshots:
     dependencies:
       react: 19.0.0-rc-a7d1240c-20240731
       scheduler: 0.25.0-rc-3208e73e-20240730
+
+  react-fast-compare@3.2.2: {}
+
+  react-focus-lock@2.13.2(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731):
+    dependencies:
+      '@babel/runtime': 7.25.6
+      focus-lock: 1.3.5
+      prop-types: 15.8.1
+      react: 19.0.0-rc-a7d1240c-20240731
+      react-clientside-effect: 1.2.6(react@19.0.0-rc-a7d1240c-20240731)
+      use-callback-ref: 1.3.2(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731)
+      use-sidecar: 1.1.2(@types/react@18.3.3)(react@19.0.0-rc-a7d1240c-20240731)
+    optionalDependencies:
+      '@types/react': 18.3.3
 
   react-is@16.13.1: {}
 
@@ -14291,6 +15626,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toggle-selection@1.0.6: {}
+
   toidentifier@1.0.1: {}
 
   toml@3.0.0: {}
@@ -14368,6 +15705,8 @@ snapshots:
       json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tslib@2.4.0: {}
 
   tslib@2.6.2: {}
 


### PR DESCRIPTION
With this PR the framework in development mode relies on Vite's dependency optimizer in a cleaner and simpler way to handle CommonJS dependencies.

Adds a new Chakra UI example to have another third-party library usage as a test case for module resolution.

Cleans up some inline Vite / Rollup plugin code.

Another possible enhancement to fix issues around third-party libraries, related to issues:
- Mantine / use client not respected https://github.com/lazarv/react-server/issues/20
- MUI 6.x / React__namespace.createContext is not a function https://github.com/lazarv/react-server/issues/22