### PR TITLE
fix: stylesheet ordering

### DIFF
--- a/packages/react-server-router/plugin.mjs
+++ b/packages/react-server-router/plugin.mjs
@@ -1031,7 +1031,7 @@ export default function viteReactServerRouter(options = {}) {
                   entry.pages.find(({ src: entrySrc }) => entrySrc === src)
                     .module
                 }")))?.file;
-                pageStyles.push(...collectStylesheets?.(pageModule));
+                pageStyles.unshift(...collectStylesheets?.(pageModule));
 
                 ${layouts
                   .map(
@@ -1046,7 +1046,7 @@ export default function viteReactServerRouter(options = {}) {
                       entry.pages.find(({ src: entrySrc }) => entrySrc === src)
                         .module
                     }")))?.file;
-                pageStyles.push(...collectStylesheets?.(__react_server_router_layout_css_${i}__));`
+                pageStyles.unshift(...collectStylesheets?.(__react_server_router_layout_css_${i}__));`
                   )
                   .join("\n")}
 
@@ -1059,12 +1059,12 @@ export default function viteReactServerRouter(options = {}) {
                       entry.pages.find(({ src: entrySrc }) => entrySrc === src)
                         .module
                     }"))?.file;
-                pageStyles.push(...collectStylesheets?.(__react_server_router_css_${i}__));`
+                pageStyles.unshift(...collectStylesheets?.(__react_server_router_css_${i}__));`
                   )
                   .join("\n")}
               }`
                   : `const pageModule = __require.resolve("${src}", { paths: [cwd] });
-              pageStyles.push(...collectStylesheets?.(pageModule));
+              pageStyles.unshift(...collectStylesheets?.(pageModule));
 
               ${[
                 ...layouts,
@@ -1078,7 +1078,7 @@ export default function viteReactServerRouter(options = {}) {
                     [src],
                     i
                   ) => `const __react_server_router_css_${i}__ = __require.resolve("${src}", { paths: [cwd] });
-              pageStyles.push(...collectStylesheets?.(__react_server_router_css_${i}__));`
+              pageStyles.unshift(...collectStylesheets?.(__react_server_router_css_${i}__));`
                 )
                 .join("\n")}`
               }

--- a/packages/react-server/lib/dev/create-server.mjs
+++ b/packages/react-server/lib/dev/create-server.mjs
@@ -455,7 +455,7 @@ export default async function createServer(root, options) {
             (mod) => !/\.(css|scss|less)/.test(mod.id)
           );
 
-          styles.push(...importedStyles.map((mod) => mod.url));
+          styles.unshift(...importedStyles.map((mod) => mod.url));
           imports.forEach((mod) => mod.id && collectCss(mod.id));
         }
       }

--- a/packages/react-server/lib/start/manifest.mjs
+++ b/packages/react-server/lib/start/manifest.mjs
@@ -136,7 +136,7 @@ export async function init$(type = "server", options = {}) {
     function collectCss(entry) {
       if (!entry) return styles;
       if (entry.css) {
-        styles.push(...entry.css.map((href) => `/${href}`));
+        styles.unshift(...entry.css.map((href) => `/${href}`));
       }
       if (entry.imports) {
         entry.imports.forEach((imported) => collectCss(manifestEnv[imported]));


### PR DESCRIPTION
Fixes stylesheet ordering when collecting imported stylesheets in dev mode / production mode / file-system based router. Stylesheets imported by a parent module should be loaded first to maintain CSS specificity.