### PR TITLE
fix: react-is alias resolution

### DIFF
--- a/packages/react-server/lib/loader/module-alias.mjs
+++ b/packages/react-server/lib/loader/module-alias.mjs
@@ -46,7 +46,12 @@ export function moduleAliases(condition) {
   const reactServerDomWebpackServerEdge = __require.resolve(
     "react-server-dom-webpack/server.edge"
   );
-  const reactIs = __require.resolve("react-is");
+  let reactIs;
+  try {
+    reactIs = __require.resolve("react-is");
+  } catch {
+    // noop
+  }
   const picocolors = __require.resolve("picocolors");
   let vite;
   try {


### PR DESCRIPTION
Fixes `react-is` alias module resolution to make it optional when package is not part of the production build.