### PR TITLE
fix: applying resolve.alias config

### DIFF
--- a/examples/photos/src/app/(root).layout.tsx
+++ b/examples/photos/src/app/(root).layout.tsx
@@ -1,8 +1,7 @@
 import "./global.css";
 
+import GithubCorner from "@/components/github-corner/GithubCorner";
 import { ReactServerComponent } from "@lazarv/react-server/navigation";
-
-import GithubCorner from "../components/github-corner/GithubCorner";
 
 export default function Layout({
   modal,

--- a/examples/photos/src/app/@modal/photos/[id].page.tsx
+++ b/examples/photos/src/app/@modal/photos/[id].page.tsx
@@ -1,6 +1,6 @@
-import Frame from "../../../components/frame/Frame";
-import Modal from "../../../components/modal/Modal";
-import photos from "../../../photos";
+import Frame from "@/components/frame/Frame";
+import Modal from "@/components/modal/Modal";
+import photos from "@/photos";
 
 export default function PhotoModal({ id: photoId }: { id: string }) {
   const photo = photos.find((p) => p.id === photoId);

--- a/examples/photos/src/app/page.tsx
+++ b/examples/photos/src/app/page.tsx
@@ -1,6 +1,5 @@
+import swagPhotos from "@/photos";
 import { Link } from "@lazarv/react-server/navigation";
-
-import swagPhotos from "../photos";
 
 export const ttl = 30000;
 

--- a/examples/photos/src/components/frame/Frame.tsx
+++ b/examples/photos/src/components/frame/Frame.tsx
@@ -1,4 +1,4 @@
-import { Photo } from "../../photos";
+import { Photo } from "@/photos";
 
 export default function Frame({ photo }: { photo: Photo }) {
   return (

--- a/examples/photos/tsconfig.json
+++ b/examples/photos/tsconfig.json
@@ -7,7 +7,11 @@
     "types": ["react/experimental", "react-dom/experimental"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "plugins": [{ "name": "typescript-plugin-css-modules" }]
+    "plugins": [{ "name": "typescript-plugin-css-modules" }],
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": ["**/*.ts", "**/*.tsx", ".react-server/**/*.ts"],
   "exclude": ["**/*.js", "**/*.mjs"]

--- a/examples/photos/vite.config.mjs
+++ b/examples/photos/vite.config.mjs
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@/": new URL("src/", import.meta.url).pathname,
+    },
+  },
+});

--- a/packages/react-server/lib/build/client.mjs
+++ b/packages/react-server/lib/build/client.mjs
@@ -9,10 +9,11 @@ import { build as viteBuild } from "vite";
 
 import { forRoot } from "../../config/index.mjs";
 import merge from "../../lib/utils/merge.mjs";
+import resolveWorkspace from "../plugins/resolve-workspace.mjs";
 import rollupUseClient from "../plugins/use-client.mjs";
 import rollupUseServer from "../plugins/use-server.mjs";
-import resolveWorkspace from "../plugins/resolve-workspace.mjs";
 import * as sys from "../sys.mjs";
+import { makeResolveAlias } from "../utils/config.mjs";
 import {
   filterOutVitePluginReact,
   userOrBuiltInVitePluginReact,
@@ -79,7 +80,7 @@ export default async function clientBuild(_, options) {
           replacement: join(sys.rootDir, "client"),
         },
         ...clientAlias(options.dev),
-        ...(config.resolve?.alias ?? []),
+        ...makeResolveAlias(config.resolve?.alias ?? []),
       ],
     },
     customLogger,

--- a/packages/react-server/lib/build/server.mjs
+++ b/packages/react-server/lib/build/server.mjs
@@ -1,28 +1,28 @@
 import { writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { join } from "node:path";
-import { pathToFileURL } from "node:url";
 
 import replace from "@rollup/plugin-replace";
 import { build as viteBuild } from "vite";
 
 import { forRoot } from "../../config/index.mjs";
-import merge from "../../lib/utils/merge.mjs";
+import fileRouter from "../plugins/file-router/plugin.mjs";
 import reactServerEval from "../plugins/react-server-eval.mjs";
 import resolveWorkspace from "../plugins/resolve-workspace.mjs";
+import rootModule from "../plugins/root-module.mjs";
 import rollupUseClient from "../plugins/use-client.mjs";
 import rollupUseServerInline from "../plugins/use-server-inline.mjs";
 import rollupUseServer from "../plugins/use-server.mjs";
-import rootModule from "../plugins/root-module.mjs";
-import fileRouter from "../plugins/file-router/plugin.mjs";
 import * as sys from "../sys.mjs";
+import { makeResolveAlias } from "../utils/config.mjs";
+import merge from "../utils/merge.mjs";
+import { bareImportRE } from "../utils/module.mjs";
 import {
   filterOutVitePluginReact,
   userOrBuiltInVitePluginReact,
 } from "../utils/plugins.mjs";
 import banner from "./banner.mjs";
 import customLogger from "./custom-logger.mjs";
-import { bareImportRE } from "../utils/module.mjs";
 
 const __require = createRequire(import.meta.url);
 const cwd = sys.cwd();
@@ -53,7 +53,7 @@ export default async function serverBuild(root, options) {
           find: /^@lazarv\/react-server\/client$/,
           replacement: join(sys.rootDir, "client"),
         },
-        ...(config.resolve?.alias ?? []),
+        ...makeResolveAlias(config.resolve?.alias ?? []),
       ],
       conditions: ["react-server"],
       externalConditions: ["react-server"],

--- a/packages/react-server/lib/dev/create-server.mjs
+++ b/packages/react-server/lib/dev/create-server.mjs
@@ -48,6 +48,7 @@ import useClient from "../plugins/use-client.mjs";
 import useServer from "../plugins/use-server.mjs";
 import useServerInline from "../plugins/use-server-inline.mjs";
 import * as sys from "../sys.mjs";
+import { makeResolveAlias } from "../utils/config.mjs";
 import { replaceError } from "../utils/error.mjs";
 import merge from "../utils/merge.mjs";
 import { bareImportRE, findPackageRoot, tryStat } from "../utils/module.mjs";
@@ -145,7 +146,7 @@ export default async function createServer(root, options) {
           find: /^@lazarv\/react-server\/client$/,
           replacement: join(sys.rootDir, "client"),
         },
-        ...(config.resolve?.alias ?? []),
+        ...makeResolveAlias(config.resolve?.alias),
       ],
       noExternal: [bareImportRE],
     },

--- a/packages/react-server/lib/utils/config.mjs
+++ b/packages/react-server/lib/utils/config.mjs
@@ -1,0 +1,14 @@
+export function makeResolveAlias(alias) {
+  if (alias && typeof alias === "object") {
+    if (Array.isArray(alias)) {
+      return alias.map((item) =>
+        typeof item === "string" ? { find: item, replacement: item } : item
+      );
+    }
+    return Object.entries(alias).map(([key, value]) => ({
+      find: key,
+      replacement: value,
+    }));
+  }
+  return [];
+}


### PR DESCRIPTION
Support an object as `resolve.alias` configuration in Vite / react-server configuration files.
Use path aliases in Photos example to use `resolve.alias` as an object.