### PR TITLE
feat: optimize deps enhancements

### DIFF
--- a/examples/mantine/react-server.config.mjs
+++ b/examples/mantine/react-server.config.mjs
@@ -4,15 +4,6 @@ export default {
   optimizeDeps: {
     exclude: ["@mantine/core"],
   },
-  resolve: {
-    alias: [
-      {
-        find: "highlight.js",
-        replacement: "highlight.js",
-      },
-    ],
-    external: ["dayjs"],
-  },
   build: {
     chunkSizeWarningLimit: 1000,
     rollupOptions: {

--- a/examples/mantine/src/components/AppLayout.tsx
+++ b/examples/mantine/src/components/AppLayout.tsx
@@ -40,11 +40,9 @@ export function AppLayout({
           </Link>
         </Group>
       </AppShell.Header>
-
       <AppShell.Navbar p="md">
         <MainNavigation serverPathname={serverPathname} />
       </AppShell.Navbar>
-
       <AppShell.Main>{children}</AppShell.Main>
     </AppShell>
   );

--- a/examples/mantine/src/components/AppLogo.tsx
+++ b/examples/mantine/src/components/AppLogo.tsx
@@ -1,4 +1,6 @@
-const SVGComponent = (props) => (
+import type { SVGProps } from "react";
+
+const SVGComponent = (props: SVGProps<SVGSVGElement>) => (
   <svg
     width="128"
     height="128"

--- a/examples/mantine/src/components/MyDates.tsx
+++ b/examples/mantine/src/components/MyDates.tsx
@@ -1,20 +1,35 @@
 "use client";
 
-import "dayjs/locale/de";
-
 import { useState } from "react";
 
+import { Select } from "@mantine/core";
 import { DateInput } from "@mantine/dates";
+import dayjs from "dayjs";
+import de from "dayjs/locale/de";
+
+dayjs.locale(de);
 
 export default function MyDates() {
   const [value, setValue] = useState<Date | null>(null);
+  const [locale, setLocale] = useState("en");
+
   return (
-    <DateInput
-      //locale="de"
-      value={value}
-      onChange={setValue}
-      label="Date input"
-      placeholder="Date input"
-    />
+    <>
+      <Select
+        data={[
+          { value: "en", label: "English" },
+          { value: "de", label: "German" },
+        ]}
+        value={locale}
+        onChange={(value) => setLocale(value ?? "en")}
+      />
+      <DateInput
+        locale={locale}
+        value={value}
+        onChange={setValue}
+        label="Date input"
+        placeholder="Date input"
+      />
+    </>
   );
 }

--- a/examples/todo/react-server.config.json
+++ b/examples/todo/react-server.config.json
@@ -1,5 +1,0 @@
-{
-  "resolve": {
-    "external": ["better-sqlite3"]
-  }
-}

--- a/packages/react-server/lib/dev/create-server.mjs
+++ b/packages/react-server/lib/dev/create-server.mjs
@@ -106,6 +106,7 @@ export default async function createServer(root, options) {
     clearScreen: options.clearScreen,
     configFile: false,
     optimizeDeps: {
+      holdUntilCrawlEnd: true,
       ...config.optimizeDeps,
       force: options.force || config.optimizeDeps?.force,
       include: [


### PR DESCRIPTION
This PR makes some changes to have a better developer experience around module resolution and the Vite deps optimizer.

- removes need in case of some packages to define a workaround `resolve.alias` entry for it
- removes need to define a package as external for some packages
- fixes Vite deps optimizer caching
- use `holdUntilCrawlEnd` by default in Vite deps optimizer
- invalidate all modules in case of a server-side error to be able to reload modules on refresh