### PR TITLE
fix: docs outlets link

### DIFF
--- a/docs/src/pages/en/(pages)/framework/micro-frontends.mdx
+++ b/docs/src/pages/en/(pages)/framework/micro-frontends.mdx
@@ -82,7 +82,7 @@ export default function Home() {
 }
 ```
 
-It's also possible to use the `ReactServerComponent` component with the `url` and `defer` props to load a micro-frontend from a remote URL. This component is similar to the `RemoteComponent` component, but it only renders the micro-frontend on the client side. This is very similar to how Astro server islands work with the `server:defer` attribute. Learn how outlets work in the [Outlet](/framework/client-navigation#outlet) section of the documentation.
+It's also possible to use the `ReactServerComponent` component with the `url` and `defer` props to load a micro-frontend from a remote URL. This component is similar to the `RemoteComponent` component, but it only renders the micro-frontend on the client side. This is very similar to how Astro server islands work with the `server:defer` attribute. Learn how [outlets](/router/client-navigation#outlet) work in the router section of the documentation about client-side navigation.
 
 ```jsx
 import { ReactServerComponent } from "@lazarv/react-server/navigation";

--- a/package.json
+++ b/package.json
@@ -87,5 +87,5 @@
       "supertest>superagent": "9.0.2"
     }
   },
-  "packageManager": "pnpm@9.10.0+sha512.73a29afa36a0d092ece5271de5177ecbf8318d454ecd701343131b8ebc0c1a91c487da46ab77c8e596d6acf1461e3594ced4becedf8921b074fbd8653ed7051c"
+  "packageManager": "pnpm@9.11.0+sha512.0a203ffaed5a3f63242cd064c8fb5892366c103e328079318f78062f24ea8c9d50bc6a47aa3567cabefd824d170e78fa2745ed1f16b132e16436146b7688f19b"
 }


### PR DESCRIPTION
Fix link in docs at https://react-server.dev/framework/micro-frontends to https://react-server.dev/router/client-navigation
Updates pnpm to latest