### PR TITLE
fix: accept header `*/*` is a valid request

### DIFF
--- a/packages/react-server/lib/start/ssr-handler.mjs
+++ b/packages/react-server/lib/start/ssr-handler.mjs
@@ -190,6 +190,7 @@ export default async function ssrHandler(root, options = {}) {
             if (
               !accept ||
               !(
+                accept.includes("*/*") ||
                 accept.includes("text/html") ||
                 accept.includes("text/x-component") ||
                 accept.includes("application/json")


### PR DESCRIPTION
The ssr handler should return a valid result if the accept http header is or contains `*/*`.