### PR TITLE
fix: move RemoteComponent to @lazarv/react-server/remote module

### DIFF
--- a/docs/src/pages/en/(pages)/framework/micro-frontends.mdx
+++ b/docs/src/pages/en/(pages)/framework/micro-frontends.mdx
@@ -51,7 +51,7 @@ Just don't use `html`, `head` or `body` tags in your micro-frontend route as the
 The `RemoteComponent` component takes a `src` prop that specifies the URL of the micro-frontend. By using this component, you can compose your application from multiple micro-frontends, each developed and deployed independently.
 
 ```jsx
-import { RemoteComponent } from "@lazarv/react-server/router";
+import RemoteComponent from "@lazarv/react-server/remote";
 
 export default function Home() {
   return (
@@ -70,7 +70,7 @@ You can also export your hosting application while using the `RemoteComponent` a
 For streaming response to work from a micro-frontend, you need to pass `defer` as a prop to the `RemoteComponent`. The initial content will be rendered during server-side rendering, and the rest of the content will be streamed from the micro-frontend after the initial content is rendered and the `RemoteComponent` gets hydrated.
 
 ```jsx
-import { RemoteComponent } from "@lazarv/react-server/router";
+import RemoteComponent from "@lazarv/react-server/remote";
 
 export default function Home() {
   return (

--- a/examples/remote/index.jsx
+++ b/examples/remote/index.jsx
@@ -1,4 +1,4 @@
-import { RemoteComponent } from "@lazarv/react-server/router";
+import RemoteComponent from "@lazarv/react-server/remote";
 
 import HostButton from "./HostButton.jsx";
 

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -31,6 +31,10 @@
       "default": "./server/router.jsx",
       "types": "./server/router.d.ts"
     },
+    "./remote": {
+      "default": "./server/remote.jsx",
+      "types": "./server/remote.d.ts"
+    },
     "./prerender": {
       "default": "./server/prerender.jsx",
       "types": "./server/prerender.d.ts"

--- a/packages/react-server/server/remote.d.ts
+++ b/packages/react-server/server/remote.d.ts
@@ -1,0 +1,30 @@
+/**
+ * Loads a remote component from the given URL. The component is fetched and rendered on the server side and if contains any client components, they are hydrated on the client side. For client components to work properly, you might need to use an import map. If the component is streamed, use the `defer` option to re-fetch the component after the initial render on the client side.
+ *
+ * @param src The URL of the remote component
+ * @param ttl The time-to-live for the component, the remote component is cached for the given time
+ * @param defer If true, the component is re-fetched after the initial render on the client side
+ * @param request The request options for the fetch request
+ * @param onError The error handler for the fetch request
+ *
+ * @example
+ *
+ * ```tsx
+ * import RemoteComponent from '@lazarv/react-server/remote';
+ *
+ * export default function App() {
+ *   return (
+ *     <>
+ *       <h1>App</h1>
+ *       <RemoteComponent src="https://example.com/remote-component" />
+ *    </>
+ *  );
+ * }
+ */
+export const RemoteComponent: React.FC<{
+  src: string;
+  ttl?: number;
+  defer?: boolean;
+  request?: RequestInit;
+  onError?: (error: Error) => void;
+}>;

--- a/packages/react-server/server/remote.jsx
+++ b/packages/react-server/server/remote.jsx
@@ -1,0 +1,3 @@
+import RemoteComponent from "./RemoteComponent.jsx";
+
+export default RemoteComponent;

--- a/packages/react-server/server/router.d.ts
+++ b/packages/react-server/server/router.d.ts
@@ -130,34 +130,3 @@ export function useMatch<T = RouteParams>(
   path: string,
   options?: MatchOptions
 ): T | null;
-
-/**
- * Loads a remote component from the given URL. The component is fetched and rendered on the server side and if contains any client components, they are hydrated on the client side. For client components to work properly, you might need to use an import map. If the component is streamed, use the `defer` option to re-fetch the component after the initial render on the client side.
- *
- * @param src The URL of the remote component
- * @param ttl The time-to-live for the component, the remote component is cached for the given time
- * @param defer If true, the component is re-fetched after the initial render on the client side
- * @param request The request options for the fetch request
- * @param onError The error handler for the fetch request
- *
- * @example
- *
- * ```tsx
- * import { RemoteComponent } from '@lazarv/react-server/router';
- *
- * export default function App() {
- *   return (
- *     <>
- *       <h1>App</h1>
- *       <RemoteComponent src="https://example.com/remote-component" />
- *    </>
- *  );
- * }
- */
-export const RemoteComponent: React.FC<{
-  src: string;
-  ttl?: number;
-  defer?: boolean;
-  request?: RequestInit;
-  onError?: (error: Error) => void;
-}>;

--- a/packages/react-server/server/router.jsx
+++ b/packages/react-server/server/router.jsx
@@ -1,5 +1,4 @@
 import { useActionState } from "./action-state.mjs";
-import RemoteComponent from "./RemoteComponent.jsx";
 import Route, { useMatch } from "./Route.jsx";
 
-export { RemoteComponent, Route, useActionState, useMatch };
+export { Route, useActionState, useMatch };


### PR DESCRIPTION
This PR moves the `RemoteComponent` into it's own module at `@lazarv/react-server/remote` to resolve an eager client component import issue around `ReactServerComponent` and `@lazarv/react-server/navigation` forcing all apps to use the navigation client components. Long-term solution will be to not build client component entries which were not used by the application even when the client component was imported in any way and to make tree-shaking work for client component references.