### PR TITLE
fix: examples test suite

### DIFF
--- a/test/__test__/apps/mantine.spec.mjs
+++ b/test/__test__/apps/mantine.spec.mjs
@@ -5,6 +5,7 @@ import {
   nextAnimationFrame,
   page,
   server,
+  waitForChange,
   waitForHydration,
 } from "playground/utils";
 import { expect, test } from "vitest";
@@ -93,13 +94,17 @@ test(
     await search.fill("Home");
     await nextAnimationFrame();
     await search.blur();
-    await page.waitForTimeout(100);
 
+    await waitForChange(
+      null,
+      () => page.getByRole("button", { name: "Home" }).isVisible(),
+      false
+    );
     const homeItem = await page.getByRole("button", { name: "Home" });
     expect(await homeItem.isVisible()).toBe(true);
 
     await homeItem.click();
-    await page.waitForTimeout(500);
+    await waitForChange(null, () => search.isVisible(), true);
     expect(await search.isVisible()).toBe(false);
 
     await page.goto(new URL("/carousel", hostname).href);
@@ -115,7 +120,11 @@ test(
     const right = await page.locator("button[tabindex='0']");
     await right.click();
 
-    await page.waitForTimeout(100);
+    await waitForChange(
+      null,
+      () => carouselContainer.getAttribute("style"),
+      "transform: translate3d(0px, 0px, 0px);"
+    );
     const rightStyle = await carouselContainer.getAttribute("style");
     expect(rightStyle).not.toEqual(carouselContainerStyle);
 
@@ -126,7 +135,11 @@ test(
     const startProgress = await page.getByRole("button", { name: "Start" });
     await startProgress.click();
 
-    await page.waitForTimeout(500);
+    await waitForChange(
+      null,
+      () => page.locator("div[role='progressbar']").isVisible(),
+      false
+    );
     const progressBar = await page.locator("div[role='progressbar']");
     expect(await progressBar.isVisible()).toBe(true);
 
@@ -138,8 +151,12 @@ test(
       name: "Open confirm modal",
     });
     await openConfirmModal.click();
-    await page.waitForTimeout(100);
 
+    await waitForChange(
+      null,
+      () => page.locator("section[role='dialog']").isVisible(),
+      false
+    );
     const confirmModal = await page.locator("section[role='dialog']");
     expect(await confirmModal.isVisible()).toBe(true);
 
@@ -147,7 +164,8 @@ test(
       name: "Confirm",
     });
     await confirmModalClose.click();
-    await page.waitForTimeout(500);
+
+    await waitForChange(null, () => confirmModal.isVisible(), true);
     expect(await confirmModal.isVisible()).toBe(false);
 
     await page.goto(new URL("/rte", hostname).href);

--- a/test/__test__/apps/mantine.spec.mjs
+++ b/test/__test__/apps/mantine.spec.mjs
@@ -16,7 +16,18 @@ test(
   "mantine and extensions",
   async () => {
     await server(null);
-    await page.goto(hostname, { timeout: 60000 });
+    let res = await page.goto(hostname, { timeout: 60000 });
+
+    // TODO: I don't like this, but it's a workaround for an async dependency optimization issue in development mode
+    let attempts = 0;
+    while (res.status() === 500 && attempts < 5) {
+      res = await page.goto(hostname, { timeout: 60000 });
+      attempts++;
+    }
+
+    if (!res.ok) {
+      throw new Error("Failed to load page");
+    }
 
     await page.waitForLoadState("networkidle");
     await waitForHydration();

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -6,8 +6,11 @@ export function nextAnimationFrame() {
   return page.evaluate(() => new Promise(requestAnimationFrame));
 }
 
-export async function waitForChange(action, getValue) {
+export async function waitForChange(action, getValue, initialValue) {
   const originalValue = await getValue();
+  if (typeof initialValue !== "undefined" && initialValue !== originalValue) {
+    return originalValue;
+  }
   let newValue = originalValue;
   while (newValue === originalValue) {
     await action?.();

--- a/test/vitest.config.build.mjs
+++ b/test/vitest.config.build.mjs
@@ -1,6 +1,4 @@
-import { setEnv } from "@lazarv/react-server/lib/sys.mjs";
-
 import baseConfig from "./vitest.config.mjs";
 
-setEnv("production");
+process.env.NODE_ENV = "production";
 export default baseConfig;

--- a/test/vitestSetup.mjs
+++ b/test/vitestSetup.mjs
@@ -90,7 +90,7 @@ beforeAll(async ({ name, id }) => {
             server: true,
             client: true,
             export: false,
-            adapter: false,
+            adapter: ["false"],
             minify: false,
           };
           await build(


### PR DESCRIPTION
Fixes "examples" test suite by removing timeout waits and using change-based waits.
Fixes disabling adapters while running tests.
Fixes build and start `NODE_ENV` set to production.
Adds retry logic to the Mantine test case to reload the page when a server-side error occurs, providing a workaround for now for an async dependency optimization issue.