### PR TITLE
fix: useCache concurrency

### DIFF
--- a/test/__test__/apps/spa.spec.mjs
+++ b/test/__test__/apps/spa.spec.mjs
@@ -9,6 +9,7 @@ test("single-page application load", async () => {
   await server("./src/index.jsx");
   await page.goto(hostname);
   await waitForHydration();
-  await page.getByText("single-page application");
-  expect(await page.textContent("body")).toContain("single-page application");
+  expect(await page.getByText("single-page application").isVisible()).toBe(
+    true
+  );
 });

--- a/test/__test__/basic.spec.mjs
+++ b/test/__test__/basic.spec.mjs
@@ -3,6 +3,7 @@ import {
   logs,
   page,
   server,
+  serverLogs,
   waitForChange,
   waitForConsole,
 } from "playground/utils";
@@ -205,4 +206,14 @@ test("use cache invalidate", async () => {
   await button.click();
 
   expect(await page.textContent("pre")).not.toContain(payload.timestamp);
+});
+
+test("use cache concurrency", async () => {
+  await server("fixtures/use-cache-concurrency.jsx");
+
+  await Promise.all([
+    fetch(hostname, { headers: { accept: "text/html" } }),
+    fetch(hostname, { headers: { accept: "text/html" } }),
+  ]);
+  expect(JSON.stringify(serverLogs)).toBe(`["getTodos"]`);
 });

--- a/test/__test__/basic.spec.mjs
+++ b/test/__test__/basic.spec.mjs
@@ -191,14 +191,21 @@ test("use cache element", async () => {
 
 test("use cache invalidate", async () => {
   await server("fixtures/use-cache-invalidate.jsx");
+
+  const start = Date.now();
   await page.goto(hostname);
 
   const payload = JSON.parse(await page.textContent("pre"));
   await page.reload();
   expect(await page.textContent("pre")).toContain(payload.timestamp);
 
-  await page.waitForTimeout(500);
-  await page.reload();
+  await waitForChange(
+    () => page.reload(),
+    () => page.textContent("pre")
+  );
+  const end = Date.now();
+  expect(end - start).toBeGreaterThan(5000);
+
   const newPayload = JSON.parse(await page.textContent("pre"));
   expect(newPayload).not.toContain(payload.timestamp);
 

--- a/test/fixtures/use-cache-concurrency.jsx
+++ b/test/fixtures/use-cache-concurrency.jsx
@@ -1,0 +1,28 @@
+import { invalidate } from "@lazarv/react-server";
+
+async function getTodos() {
+  "use cache; ttl=10000; tags=todos";
+  console.log("getTodos");
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  const res = await fetch("https://jsonplaceholder.typicode.com/todos");
+  return {
+    timestamp: Date.now(),
+    data: await res.json(),
+  };
+}
+
+export default async function App() {
+  const todos = await getTodos();
+
+  return (
+    <form
+      action={async () => {
+        "use server";
+        invalidate(getTodos);
+      }}
+    >
+      <button type="submit">Refresh</button>
+      <pre>{JSON.stringify(todos, null, 2)}</pre>
+    </form>
+  );
+}

--- a/test/fixtures/use-cache-invalidate.jsx
+++ b/test/fixtures/use-cache-invalidate.jsx
@@ -1,7 +1,7 @@
 import { invalidate } from "@lazarv/react-server";
 
 async function getTodos() {
-  "use cache; ttl=200; tags=todos";
+  "use cache; ttl=5000; tags=todos";
   const res = await fetch("https://jsonplaceholder.typicode.com/todos");
   return {
     timestamp: Date.now(),
@@ -11,6 +11,7 @@ async function getTodos() {
 
 export default async function App() {
   const todos = await getTodos();
+
   return (
     <form
       action={async () => {

--- a/test/vitestSetup.mjs
+++ b/test/vitestSetup.mjs
@@ -28,14 +28,14 @@ beforeAll(async ({ name, id }) => {
   const wsEndpoint = inject("wsEndpoint");
   browser = await chromium.connect(wsEndpoint);
   page = await browser.newPage();
-  logs = [];
-  serverLogs = [];
   page.on("console", (msg) => {
     logs.push(msg.text());
   });
   server = (root, initialConfig) =>
     new Promise(async (resolve, reject) => {
       try {
+        logs = [];
+        serverLogs = [];
         const hashValue = createHash("sha256")
           .update(
             `${name}-${id}-${portCounter++}-${root?.[0] === "." ? join(process.cwd(), root) : root || process.cwd()}`
@@ -74,6 +74,8 @@ beforeAll(async ({ name, id }) => {
           httpServer = createServer(middlewares);
           httpServer.once("listening", () => {
             hostname = `http://localhost:${port}`;
+            logs = [];
+            serverLogs = [];
             resolve();
           });
           httpServer.on("error", (err) => {
@@ -112,6 +114,8 @@ beforeAll(async ({ name, id }) => {
             if (msg.port) {
               hostname = `http://localhost:${msg.port}`;
               process.env.ORIGIN = hostname;
+              logs = [];
+              serverLogs = [];
               resolve();
             } else if (msg.console) {
               console.log(...msg.console);

--- a/test/vitestSetup.mjs
+++ b/test/vitestSetup.mjs
@@ -7,16 +7,17 @@ import { Worker } from "node:worker_threads";
 import { chromium } from "playwright-chromium";
 import { afterAll, beforeAll, inject } from "vitest";
 
-let browser;
-let httpServer;
-
+export let browser;
+export let httpServer;
 export let page;
 export let server;
 export let hostname;
 export let logs;
+export let serverLogs;
 
 console.log = (...args) => {
   logs.push(args.join(" "));
+  serverLogs.push(args.join(" "));
 };
 
 const BASE_PORT = 3000;
@@ -28,6 +29,7 @@ beforeAll(async ({ name, id }) => {
   browser = await chromium.connect(wsEndpoint);
   page = await browser.newPage();
   logs = [];
+  serverLogs = [];
   page.on("console", (msg) => {
     logs.push(msg.text());
   });


### PR DESCRIPTION
Fixes `useCache` concurrency by introducing locking on the same key.
Adds a test case to test `"use cache"` concurrency where only a single line should be logged when serving concurrent requests.