### PR TITLE
fix: use cache in a function with params

### DIFF
--- a/packages/react-server/lib/plugins/use-cache-inline.mjs
+++ b/packages/react-server/lib/plugins/use-cache-inline.mjs
@@ -224,7 +224,7 @@ export default function useServerInline(profiles) {
             ],
           };
           cache.node.body.body = [
-            ...(cache.params.length > 0
+            ...(cache.params.length > 0 || cache.node.params.length > 0
               ? [
                   {
                     type: "VariableDeclaration",
@@ -263,7 +263,10 @@ export default function useServerInline(profiles) {
                   name: "useCache",
                 },
                 arguments: [
-                  cacheKey,
+                  {
+                    ...cacheKey,
+                    elements: [...cacheKey.elements, ...cache.node.params],
+                  },
                   {
                     type: "FunctionExpression",
                     id: null,

--- a/packages/react-server/memory-cache/index.mjs
+++ b/packages/react-server/memory-cache/index.mjs
@@ -1,3 +1,5 @@
+import equals from "deep-eql";
+
 import { context$, getContext } from "../server/context.mjs";
 import {
   CACHE_CONTEXT,
@@ -27,9 +29,7 @@ export class MemoryCache {
 
     const cacheKeys = this.cache.keys();
     for (const entryKeys of cacheKeys) {
-      if (
-        keys.every((key, keyIndex) => entryKeys[keyIndex] === key?.toString())
-      ) {
+      if (keys.every((key, keyIndex) => equals(entryKeys[keyIndex], key))) {
         return this.cache.get(entryKeys);
       }
     }
@@ -41,26 +41,19 @@ export class MemoryCache {
     if (await this.hasExpiry(keys)) {
       const cacheKeys = this.cache.keys();
       for (const entryKeys of cacheKeys) {
-        if (
-          keys.every((key, keyIndex) => entryKeys[keyIndex] === key?.toString())
-        ) {
+        if (keys.every((key, keyIndex) => equals(entryKeys[keyIndex], key))) {
           this.cache.set(entryKeys, value);
           return;
         }
       }
-      this.cache.set(
-        keys.map((key) => key?.toString()),
-        value
-      );
+      this.cache.set(keys, value);
     }
   }
 
   async has(keys) {
     const cacheKeys = this.cache.keys();
     for (const entryKeys of cacheKeys) {
-      if (
-        keys.every((key, keyIndex) => entryKeys[keyIndex] === key?.toString())
-      ) {
+      if (keys.every((key, keyIndex) => equals(entryKeys[keyIndex], key))) {
         return true;
       }
     }
@@ -71,17 +64,12 @@ export class MemoryCache {
   async setExpiry(keys, expiry) {
     const expiryKeys = this.expiry.keys();
     for (const entryKeys of expiryKeys) {
-      if (
-        keys.every((key, keyIndex) => entryKeys[keyIndex] === key?.toString())
-      ) {
+      if (keys.every((key, keyIndex) => equals(entryKeys[keyIndex], key))) {
         this.expiry.set(entryKeys, expiry);
         return;
       }
     }
-    this.expiry.set(
-      keys.map((key) => key?.toString()),
-      expiry
-    );
+    this.expiry.set(keys, expiry);
   }
 
   async hasExpiry(keys) {
@@ -89,7 +77,7 @@ export class MemoryCache {
     for (const entryKeys of expiryKeys) {
       for (let keyIndex = 0; keyIndex < entryKeys.length; keyIndex++) {
         const key = keys[keyIndex];
-        if (entryKeys[keyIndex] !== key?.toString()) {
+        if (!equals(entryKeys[keyIndex], key)) {
           break;
         }
         if (keyIndex === entryKeys.length - 1) {
@@ -104,9 +92,7 @@ export class MemoryCache {
   async delete(keys) {
     const cacheKeys = this.cache.keys();
     for (const entryKeys of cacheKeys) {
-      if (
-        keys.every((key, keyIndex) => entryKeys[keyIndex] === key?.toString())
-      ) {
+      if (keys.every((key, keyIndex) => equals(entryKeys[keyIndex], key))) {
         this.cache.delete(entryKeys);
       }
     }

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -96,6 +96,7 @@
     "ansi-regex": "^6.0.1",
     "cac": "^6.7.14",
     "chokidar": "^3.5.3",
+    "deep-eql": "^5.0.2",
     "esbuild": "^0.19.3",
     "escodegen": "^2.1.0",
     "estraverse": "^5.3.0",

--- a/packages/react-server/server/cache.mjs
+++ b/packages/react-server/server/cache.mjs
@@ -11,7 +11,7 @@ export function withCache(Component, ttl = Infinity) {
 }
 
 export function useResponseCache(ttl = Infinity) {
-  const url = useUrl()?.toString();
+  const url = useUrl();
   const accept = useRequest()?.headers?.get?.("accept");
   const outlet = useOutlet();
   const cache = getContext(CACHE_CONTEXT);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,7 +127,7 @@ importers:
         version: 1.0.12(next@14.2.8(@babel/core@7.24.7)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)(sass@1.77.6))(react@19.0.0-rc-a7d1240c-20240731)
       '@vitejs/plugin-react-swc':
         specifier: ^3.7.0
-        version: 3.7.0(@swc/helpers@0.5.5)(vite@6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.39))(terser@5.31.1))
+        version: 3.7.0(@swc/helpers@0.5.5)(vite@6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.45))(terser@5.31.1))
       algoliasearch:
         specifier: ^4.24.0
         version: 4.24.0
@@ -148,14 +148,14 @@ importers:
         version: 4.0.0
       vite-plugin-svgr:
         specifier: ^4.2.0
-        version: 4.2.0(rollup@4.24.0)(typescript@5.6.3)(vite@6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.39))(terser@5.31.1))
+        version: 4.2.0(rollup@4.24.0)(typescript@5.6.3)(vite@6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.45))(terser@5.31.1))
     devDependencies:
       '@types/react':
         specifier: ^18.3.2
         version: 18.3.3
       autoprefixer:
         specifier: ^10.4.19
-        version: 10.4.19(postcss@8.4.39)
+        version: 10.4.19(postcss@8.4.45)
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
@@ -632,6 +632,9 @@ importers:
       chokidar:
         specifier: ^3.5.3
         version: 3.6.0
+      deep-eql:
+        specifier: ^5.0.2
+        version: 5.0.2
       esbuild:
         specifier: ^0.19.3
         version: 0.19.12
@@ -12178,10 +12181,10 @@ snapshots:
       next: 14.2.8(@babel/core@7.24.7)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)(sass@1.77.6)
       react: 19.0.0-rc-a7d1240c-20240731
 
-  '@vitejs/plugin-react-swc@3.7.0(@swc/helpers@0.5.5)(vite@6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.39))(terser@5.31.1))':
+  '@vitejs/plugin-react-swc@3.7.0(@swc/helpers@0.5.5)(vite@6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.45))(terser@5.31.1))':
     dependencies:
       '@swc/core': 1.6.6(@swc/helpers@0.5.5)
-      vite: 6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.39))(terser@5.31.1)
+      vite: 6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.45))(terser@5.31.1)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -12579,6 +12582,16 @@ snapshots:
       normalize-range: 0.1.2
       picocolors: 1.0.1
       postcss: 8.4.39
+      postcss-value-parser: 4.2.0
+
+  autoprefixer@10.4.19(postcss@8.4.45):
+    dependencies:
+      browserslist: 4.23.1
+      caniuse-lite: 1.0.30001638
+      fraction.js: 4.3.7
+      normalize-range: 0.1.2
+      picocolors: 1.0.1
+      postcss: 8.4.45
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -17890,12 +17903,12 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-svgr@4.2.0(rollup@4.24.0)(typescript@5.6.3)(vite@6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.39))(terser@5.31.1)):
+  vite-plugin-svgr@4.2.0(rollup@4.24.0)(typescript@5.6.3)(vite@6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.45))(terser@5.31.1)):
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.24.0)
       '@svgr/core': 8.1.0(typescript@5.6.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.6.3))
-      vite: 6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.39))(terser@5.31.1)
+      vite: 6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.45))(terser@5.31.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -17928,20 +17941,6 @@ snapshots:
       sass: 1.77.6
       stylus: 0.62.0
       sugarss: 4.0.1(postcss@8.4.45)
-      terser: 5.31.1
-
-  vite@6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.39))(terser@5.31.1):
-    dependencies:
-      esbuild: 0.21.3
-      postcss: 8.4.45
-      rollup: 4.24.0
-    optionalDependencies:
-      '@types/node': 20.14.9
-      fsevents: 2.3.3
-      less: 4.2.0
-      sass: 1.77.6
-      stylus: 0.62.0
-      sugarss: 4.0.1(postcss@8.4.39)
       terser: 5.31.1
 
   vite@6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.45))(terser@5.31.1):

--- a/test/__test__/basic.spec.mjs
+++ b/test/__test__/basic.spec.mjs
@@ -224,3 +224,18 @@ test("use cache concurrency", async () => {
   ]);
   expect(JSON.stringify(serverLogs)).toBe(`["getTodos"]`);
 });
+
+test("use cache dynamic", async () => {
+  await server("fixtures/use-cache-dynamic.jsx");
+  await page.goto(hostname + "?id=1");
+  const time = await page.textContent("body");
+
+  await page.reload();
+  expect(await page.textContent("body")).toBe(time);
+
+  await page.goto(hostname + "?id=2");
+  expect(await page.textContent("body")).not.toBe(time);
+
+  await page.goto(hostname + "?id=1");
+  expect(await page.textContent("body")).toBe(time);
+});

--- a/test/fixtures/use-cache-dynamic.jsx
+++ b/test/fixtures/use-cache-dynamic.jsx
@@ -1,0 +1,11 @@
+import { invalidate, useSearchParams } from "@lazarv/react-server";
+
+function getTime({ id: _ }) {
+  "use cache";
+  return new Date().toISOString();
+}
+
+export default async function App() {
+  const { id } = useSearchParams();
+  return <div>{getTime({ id })}</div>;
+}

--- a/test/vitest.config.mjs
+++ b/test/vitest.config.mjs
@@ -23,7 +23,7 @@ export default defineConfig({
       ? ["dot", "github-actions"]
       : ["default"],
     pool: "forks",
-    fileParallelism: false,
+    fileParallelism: !process.env.CI,
   },
   publicDir: false,
 });


### PR DESCRIPTION
Fixes `"use cache"` when using the directive in a function with params where the param should be included in the cache key.
Changes in-memory cache implementation to use `deep-eql` for deep equality check on the cache key segments.