### PR TITLE
fix(docs): sidebar scroll container

### DIFF
--- a/docs/src/components/Sidebar.module.css
+++ b/docs/src/components/Sidebar.module.css
@@ -126,7 +126,6 @@ article ~ .root {
     position: sticky;
     top: 0;
     align-self: flex-start;
-    min-height: min-content;
     max-height: calc(100vh - 48px);
     margin-top: -1rem;
     height: auto;


### PR DESCRIPTION
### Description

On media query screens of `lg` the `Sidebar` scroll breaks due to `min-height: min-content`

### Changes

- [x] fix: sidebar scroll

### Result

**Before**

https://github.com/user-attachments/assets/7fa2b4c4-3b92-464e-b8ad-43855a11c80d

**After**

https://github.com/user-attachments/assets/5f5e13af-c68c-4fa9-ba04-f738850c0134