### PR TITLE
fix(docs): table of contents rendering

### DIFF
--- a/docs/src/components/Sidebar.module.css
+++ b/docs/src/components/Sidebar.module.css
@@ -110,11 +110,6 @@ article ~ .root {
   overflow-x: hidden;
   overflow-y: auto;
   pointer-events: auto;
-  /* view-transition-name: sidebar; */
-
-  &:has(nav:empty) {
-    @apply hidden;
-  }
 
   @media (prefers-reduced-motion) {
     view-transition-name: none;

--- a/docs/src/components/TableOfContents.jsx
+++ b/docs/src/components/TableOfContents.jsx
@@ -81,8 +81,6 @@ export default function TableOfContents() {
     };
   }, []);
 
-  if (tableOfContents.length < 2) return null;
-
   return (
     <>
       <header className="text-md font-semibold mb-2 whitespace-nowrap">

--- a/docs/src/pages/@contents/[[lang]]/[category]/(table-of-contents).[...slug].page.jsx
+++ b/docs/src/pages/@contents/[[lang]]/[category]/(table-of-contents).[...slug].page.jsx
@@ -1,7 +1,17 @@
+import { usePathname } from "@lazarv/react-server";
+
 import Sidebar from "../../../../components/Sidebar.jsx";
 import TableOfContents from "../../../../components/TableOfContents.jsx";
+import { getPages } from "../../../../pages.mjs";
 
-export default function Contents() {
+export default function Contents({ lang, category }) {
+  const pathname = usePathname();
+  const { frontmatter } = getPages(pathname, lang)
+    .find(({ category: c }) => c.toLowerCase() === category.toLowerCase())
+    ?.pages.find(({ langHref }) => langHref === pathname);
+
+  if (frontmatter?.contents === false) return null;
+
   return (
     <Sidebar id="contents" menu="On this page" right>
       <TableOfContents />

--- a/docs/src/pages/en/(pages)/deploy/api.mdx
+++ b/docs/src/pages/en/(pages)/deploy/api.mdx
@@ -10,7 +10,9 @@ import Link from "../../../../components/Link"
 
 By using the Adapter API available in the `@lazarv/react-server-adapter-core` package, you can easily create a deployment adapter for any deployment target.
 
+<Link name="define-the-adapter-handler">
 ## Define the adapter handler
+</Link>
 
 The adapter handler is a function that you need to implement to handle the deployment of your application. It will be called by the build process and it will receive the information needed to prepare the application for deployment.
 
@@ -55,7 +57,9 @@ You need to pass adapter properties to the `createAdapter` function to configure
 
 `deploy`: The deployment command and arguments. This is optional. When provided, the adapter will show what command the developer needs to run to deploy the application after it has been built. If the `--deploy` flag is provided during the build, the adapter will run this command.
 
+<Link name="adapter-handler">
 ## Adapter handler
+</Link>
 
 The adapter handler function will receive the following properties:
 
@@ -95,7 +99,9 @@ The `copy` object contains the following functions:
 await copy.server(outServerDir);
 ```
 
+<Link name="helper-functions">
 ## Helper functions
+</Link>
 
 ### banner
 

--- a/docs/src/pages/en/(pages)/framework/cluster.mdx
+++ b/docs/src/pages/en/(pages)/framework/cluster.mdx
@@ -2,6 +2,7 @@
 title: Cluster mode
 category: Framework
 order: 10
+contents: false
 ---
 
 # Cluster Mode

--- a/docs/src/pages/en/(pages)/framework/ppr.mdx
+++ b/docs/src/pages/en/(pages)/framework/ppr.mdx
@@ -2,6 +2,7 @@
 title: Partial pre-rendering
 category: Framework
 order: 5
+contents: false
 ---
 
 # Partial pre-rendering

--- a/docs/src/pages/en/(pages)/integrations/mantine.mdx
+++ b/docs/src/pages/en/(pages)/integrations/mantine.mdx
@@ -2,6 +2,7 @@
 title: Mantine UI
 category: Integrations
 order: 5
+contents: false
 ---
 
 import Link from "../../../../components/Link.jsx";

--- a/docs/src/pages/en/(pages)/integrations/mui.mdx
+++ b/docs/src/pages/en/(pages)/integrations/mui.mdx
@@ -2,6 +2,7 @@
 title: Material UI
 category: Integrations
 order: 6
+contents: false
 ---
 
 import Link from "../../../../components/Link.jsx";

--- a/docs/src/pages/en/(pages)/integrations/react-query.mdx
+++ b/docs/src/pages/en/(pages)/integrations/react-query.mdx
@@ -2,6 +2,7 @@
 title: TanStack Query
 category: Integrations
 order: 4
+contents: false
 ---
 
 import Link from "../../../../components/Link.jsx";

--- a/docs/src/pages/en/(pages)/team/contributors.mdx
+++ b/docs/src/pages/en/(pages)/team/contributors.mdx
@@ -3,6 +3,7 @@ title: Contributors
 category: Team
 order: 1
 slug: team/contributors
+contents: false
 ---
 
 import Contributors from "../../../../components/Contributors";


### PR DESCRIPTION
This PR fixes the rendering of the table of contents in the docs by using a frontmatter flag to determine during SSR whether a contents sidebar should be rendered.