### PR TITLE
fix: support async functions as static parameters input in file-system based router

### DIFF
--- a/packages/react-server/lib/plugins/file-router/plugin.mjs
+++ b/packages/react-server/lib/plugins/file-router/plugin.mjs
@@ -785,23 +785,16 @@ export default function viteReactServerRouter(options = {}) {
                     }
                     return { path };
                   }
-                  if (typeof staticPaths === "function") {
-                    return await staticPaths();
-                  }
                   const validPaths = await Promise.all(
                     staticPaths.map(async (def) => {
                       let obj = def;
                       if (typeof def === "function") {
                         obj = await def();
                       }
-                      try {
-                        return { path: applyParamsToPath(path, obj) };
-                      } catch (e) {
-                        if (typeof obj.path === "string") {
-                          return { path: obj.path };
-                        }
-                        throw e;
+                      if (typeof obj.path === "string") {
+                        return { path: obj.path };
                       }
+                      return { path: applyParamsToPath(path, obj) };
                     })
                   );
                   return validPaths;

--- a/packages/react-server/lib/plugins/file-router/plugin.mjs
+++ b/packages/react-server/lib/plugins/file-router/plugin.mjs
@@ -771,7 +771,10 @@ export default function viteReactServerRouter(options = {}) {
                 config.build.rollupOptions.input[join("static", hash)] =
                   staticSrc;
                 paths.push(async () => {
-                  const staticPaths = (await import(exportEntry)).default;
+                  let staticPaths = (await import(exportEntry)).default;
+                  if (typeof staticPaths === "function") {
+                    staticPaths = await staticPaths();
+                  }
                   if (typeof staticPaths === "boolean" && staticPaths) {
                     if (/\[[^\]]+\]/.test(path)) {
                       throw new Error(


### PR DESCRIPTION
Adds support for async functions as static parameters input in the file-system based router.

```ts
// [id].static.ts
export default async () => [{ id: 1 }, { id: 2 }, { id: 3 }];
```

#81 