### PR TITLE
fix: build with custom public dir

### DIFF
--- a/packages/react-server/lib/build/server.mjs
+++ b/packages/react-server/lib/build/server.mjs
@@ -99,6 +99,8 @@ export default async function serverBuild(root, options) {
     return false;
   };
 
+  const publicDir =
+    typeof config.public === "string" ? config.public : "public";
   const buildConfig = {
     root: cwd,
     configFile: false,
@@ -232,6 +234,7 @@ export default async function serverBuild(root, options) {
         externalConditions: ["react-server"],
       },
     },
+    publicDir: join(cwd, publicDir),
   };
 
   let viteConfig = buildConfig;


### PR DESCRIPTION
Adds missing `publicDir` configuration to build Vite config to enable custom public directory configuration other than the default `public`. #82 