### PR TITLE
fix: encode headers and use charset utf-8 on content-type response headers

### DIFF
--- a/packages/react-server/client/ClientProvider.jsx
+++ b/packages/react-server/client/ClientProvider.jsx
@@ -243,7 +243,7 @@ export const streamOptions = (outlet, remote) => ({
             )
               ? {}
               : {
-                  "React-Server-Action": id,
+                  "React-Server-Action": encodeURIComponent(id),
                 },
           });
           emit(target, url, (err, result) => {
@@ -258,8 +258,8 @@ export const streamOptions = (outlet, remote) => ({
               body: formData,
               headers: {
                 accept: "application/json",
-                "React-Server-Action": id,
-                "React-Server-Outlet": outlet || PAGE_ROOT,
+                "React-Server-Action": encodeURIComponent(id),
+                "React-Server-Outlet": encodeURIComponent(outlet || PAGE_ROOT),
               },
             }
           );
@@ -304,7 +304,9 @@ function getFlightResponse(url, options = {}) {
               accept: `text/x-component${
                 options.standalone && url !== PAGE_ROOT ? ";standalone" : ""
               }${options.remote && url !== PAGE_ROOT ? ";remote" : ""}`,
-              "React-Server-Outlet": options.outlet || PAGE_ROOT,
+              "React-Server-Outlet": encodeURIComponent(
+                options.outlet || PAGE_ROOT
+              ),
               ...options.headers,
             },
           }),

--- a/packages/react-server/lib/handlers/error.mjs
+++ b/packages/react-server/lib/handlers/error.mjs
@@ -104,7 +104,7 @@ function plainResponse(e) {
   return new Response(e?.stack ?? null, {
     ...httpStatus,
     headers: {
-      "Content-Type": "text/plain",
+      "Content-Type": "text/plain; charset=utf-8",
       ...(getContext(HTTP_HEADERS) ?? {}),
     },
   });
@@ -164,7 +164,7 @@ export default async function errorHandler(err) {
       {
         ...httpStatus,
         headers: {
-          "Content-Type": "text/html",
+          "Content-Type": "text/html; charset=utf-8",
           ...(getContext(HTTP_HEADERS) ?? {}),
         },
       }

--- a/packages/react-server/lib/handlers/static.mjs
+++ b/packages/react-server/lib/handlers/static.mjs
@@ -50,7 +50,7 @@ export default async function staticHandler(dir, options = {}) {
     if (pathname.startsWith("/@source")) {
       return new Response(await readFile(pathname.slice(8), "utf8"), {
         headers: {
-          "content-type": "text/plain",
+          "content-type": "text/plain; charset=utf-8",
         },
       });
     }
@@ -178,7 +178,10 @@ export default async function staticHandler(dir, options = {}) {
           }
           return new Response(res, {
             headers: {
-              "content-type": file.mime,
+              "content-type":
+                file.mime.includes("text/") || file.mime === "application/json"
+                  ? `${file.mime}; charset=utf-8`
+                  : file.mime,
               "content-length": file.stats.size,
               etag: file.etag,
               "cache-control":

--- a/packages/react-server/lib/start/ssr-handler.mjs
+++ b/packages/react-server/lib/start/ssr-handler.mjs
@@ -127,7 +127,7 @@ export default async function ssrHandler(root, options = {}) {
     return new Response(e?.stack ?? null, {
       ...httpStatus,
       headers: {
-        "Content-Type": "text/plain",
+        "Content-Type": "text/plain; charset=utf-8",
         ...(getContext(HTTP_HEADERS) ?? {}),
       },
     });

--- a/packages/react-server/server/RemoteComponent.jsx
+++ b/packages/react-server/server/RemoteComponent.jsx
@@ -18,7 +18,7 @@ async function RemoteComponentLoader({ url, ttl, request = {}, onError }) {
             Origin: url.origin,
             ...request.headers,
             Accept: "text/html;remote",
-            "React-Server-Outlet": url.toString(),
+            "React-Server-Outlet": encodeURIComponent(url.toString()),
           },
         }).catch((e) => {
           (onError ?? getContext(LOGGER_CONTEXT)?.error)?.(e);

--- a/packages/react-server/server/redirects.mjs
+++ b/packages/react-server/server/redirects.mjs
@@ -23,7 +23,7 @@ export function redirect(url, status = 302) {
             {
               status,
               headers: {
-                "content-type": "text/html",
+                "content-type": "text/html; charset=utf-8",
                 Location: url,
               },
             }

--- a/packages/react-server/server/request.mjs
+++ b/packages/react-server/server/request.mjs
@@ -62,8 +62,8 @@ export function rewrite(pathname) {
 }
 
 export function useOutlet() {
-  return (
+  return decodeURIComponent(
     getContext(HTTP_CONTEXT)?.request?.headers?.get("react-server-outlet") ??
-    "PAGE_ROOT"
+      "PAGE_ROOT"
   );
 }


### PR DESCRIPTION
Adds encoding to HTTP headers from the client and also adds `charset=utf-8` to all HTTP `Content-Type` headers to support exotic characters in client component and server function paths and also in outlet names. #84 