### PR TITLE
fix(examples): upgrade better-sqlite3 in todo example

### DIFF
--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@lazarv/react-server": "workspace:^",
-    "better-sqlite3": "^10.0.0",
+    "better-sqlite3": "^11.6.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -545,8 +545,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/react-server
       better-sqlite3:
-        specifier: ^10.0.0
-        version: 10.1.0
+        specifier: ^11.6.0
+        version: 11.6.0
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -4135,8 +4135,8 @@ packages:
   before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
 
-  better-sqlite3@10.1.0:
-    resolution: {integrity: sha512-hqpHJaCfKEZFaAWdMh6crdzRWyzQzfP6Ih8TYI0vFn01a6ZTDSbJIMXN+6AMBaBOh99DzUy8l3PsV9R3qnJDng==}
+  better-sqlite3@11.6.0:
+    resolution: {integrity: sha512-2J6k/eVxcFYY2SsTxsXrj6XylzHWPxveCn4fKPKZFv/Vqn/Cd7lOuX4d7rGQXT5zL+97MkNL3nSbCrIoe3LkgA==}
 
   big-integer@1.6.52:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
@@ -12677,7 +12677,7 @@ snapshots:
 
   before-after-hook@2.2.3: {}
 
-  better-sqlite3@10.1.0:
+  better-sqlite3@11.6.0:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.2


### PR DESCRIPTION
Upgrade `better-sqlite3` in the Todo example to support Node.js 23.x