### PR TITLE
fix: revert remote component outlet encoding

### DIFF
--- a/packages/react-server/server/RemoteComponent.jsx
+++ b/packages/react-server/server/RemoteComponent.jsx
@@ -18,7 +18,7 @@ async function RemoteComponentLoader({ url, ttl, request = {}, onError }) {
             Origin: url.origin,
             ...request.headers,
             Accept: "text/html;remote",
-            "React-Server-Outlet": encodeURIComponent(url.toString()),
+            "React-Server-Outlet": url.toString(),
           },
         }).catch((e) => {
           (onError ?? getContext(LOGGER_CONTEXT)?.error)?.(e);


### PR DESCRIPTION
Reverts `RemoteComponent` outlet header encoding as it was a breaking change.