### PR TITLE
fix: static generated RSC x-component and response type selection

### DIFF
--- a/docs/react-server.config.mjs
+++ b/docs/react-server.config.mjs
@@ -21,6 +21,7 @@ export default {
     return [
       ...paths.map(({ path }) => ({
         path: path.replace(/^\/en/, ""),
+        rsc: false,
       })),
       {
         path: "/sitemap.xml",

--- a/docs/src/pages/en/(pages)/deploy/api.mdx
+++ b/docs/src/pages/en/(pages)/deploy/api.mdx
@@ -75,6 +75,7 @@ The adapter handler function will receive the following properties:
 The `files` object contains the following functions:
 
 - [ ] `static`: The function to get the static files.
+- [ ] `compressed`: The function to get the compressed static files.
 - [ ] `assets`: The function to get the assets files.
 - [ ] `client`: The function to get the client files.
 - [ ] `public`: The function to get the public files.
@@ -89,6 +90,7 @@ const staticFiles = await files.static();
 The `copy` object contains the following functions:
 
 - [ ] `static`: The function to copy the static files.
+- [ ] `compressed`: The function to copy the compressed static files.
 - [ ] `assets`: The function to copy the assets files.
 - [ ] `client`: The function to copy the client files.
 - [ ] `public`: The function to copy the public files.

--- a/docs/src/pages/en/(pages)/framework/cli.mdx
+++ b/docs/src/pages/en/(pages)/framework/cli.mdx
@@ -98,6 +98,9 @@ You can disable client build if you only want to build the server part of your a
 **export:** Static export. Default is `false`.  
 You can export your app as static HTML pages. You can define the routes to export in your `react-server.config.mjs` file. See more details at [Static generation](/router/static).
 
+**compression:** Enable compression. Default is `false`.  
+You can enable compression if you want to compress your static build. Compression is not enabled by default for static builds. Gzip and Brotli compression is used when compression is enabled. The production mode server serves these compressed files by default when the compressed static files are present.
+
 **deploy:** Deploy using adapter. Default is `false`.
 If you use an adapter in your `react-server.config.mjs` file, the adapter will pre-build your app for deployment and when you use this argument, the adapter will also deploy your app at the end of the build process.
 

--- a/docs/src/pages/en/(pages)/router/server-routing.mdx
+++ b/docs/src/pages/en/(pages)/router/server-routing.mdx
@@ -178,34 +178,6 @@ export default function App() {
 }
 ```
 
-<Link name="route-rendering-in-standalone-mode">
-## Route rendering in standalone-mode
-</Link>
-
-If you want a route to render only it's children when using client-side navigation, you can set the value of the `standalone` prop on the `Route` component to be `false`. This will prevent the route from using it's `render` function when the path matches the route. Upon client-side navigation or refreshing, the route will only render it's children.
-
-```tsx
-import { Route } from '@lazarv/react-server/router';
-
-function Layout({ children }) {
-  return (
-    <div>
-      <h1>Layout</h1>
-      {children}
-    </div>
-  );
-}
-
-export default function App() {
-  return (
-    <Route path="/" render={Layout} standalone={false}>
-      <Route path="/" exact element={<Home />} />
-      <Route path="/about" element={<About />} />
-    </Route>
-  );
-}
-```
-
 <Link name="redirects">
 ## Redirects
 </Link>

--- a/docs/src/pages/en/(pages)/router/static.page.mdx
+++ b/docs/src/pages/en/(pages)/router/static.page.mdx
@@ -14,13 +14,13 @@ To mark a page as static, create a file with the matching path for the page with
 
 For pages without any parameters, export default `true`.
 
-```ts
+```ts filename="users.static.ts"
 export default true;
 ```
 
 The smallest possible way to mark a page as static is by creating a `.static.json` file defining `true`.
 
-```json
+```json filename="users.static.json"
 true
 ```
 
@@ -32,13 +32,13 @@ true
 
 For dynamic routes, if you have a page at `/users/:id` you can create a file at `/users/[id].static.ts` with the following content:
 
-```ts
+```ts filename="users/[id].static.ts"
 export default [{ id: 1 }, { id: 2 }, { id: 3 }];
 ```
 
 You can either export an array of route parameters or an async function returning an array of route parameters.
 
-```ts
+```ts filename="users/[id].static.ts"
 export default async () => [{ id: 1 }, { id: 2 }, { id: 3 }];
 ```
 
@@ -52,7 +52,7 @@ You can use static JSON data for your static pages by creating a file with the `
 
 For example, if you have a page at `/users/:id` you can create a file at `/users/[id].static.json` with the following content:
 
-```json
+```json filename="users/[id].static.json"
 [{ "id": 1 }, { "id": 2 }, { "id": 3 }]
 ```
 
@@ -64,7 +64,7 @@ For example, if you have a page at `/users/:id` you can create a file at `/users
 
 You can override all static paths by defining an `export()` function in your `@lazarv/react-server` configuration file. This function will be called with an array of all static paths and you can return a new array of paths to override the default static paths. In this example, we remove the `/en` prefix from all static paths.
 
-```js
+```js filename="react-server.config.mjs"
 export default {
   export(paths) {
     return paths.map(({ path }) => ({
@@ -76,7 +76,7 @@ export default {
 
 You can also use this function to add new static paths or remove some paths.
 
-```js
+```js filename="react-server.config.mjs"
 export default {
   export(paths) {
     return [
@@ -87,7 +87,7 @@ export default {
 };
 ```
 
-```js
+```js filename="react-server.config.mjs"
 export default {
   export(paths) {
     return paths.filter(({ path }) => path !== "/en");
@@ -101,7 +101,7 @@ export default {
 
 You can also export API routes as static routes. To do this, you can define your static path as an object with the `path`, `filename`, `method` and `headers` properties, where `path` is the route path, `filename` is the filename for the static file, `method` is the HTTP method for the request and `headers` is an object with the headers for the request. `method` and `headers` are optional.
 
-```js
+```js filename="react-server.config.mjs"
 export default {
   export() {
     return [
@@ -124,7 +124,7 @@ export default {
 
 You can also export micro-frontend routes as static. To do this, you can define your static path as an object with the `path` and `remote` properties, where `path` is the route path and `remote` is a flag to indicate that the route is a micro-frontend route and the remote response payload needs to be generated at build time. By using static export for micro-frontends, you can improve the performance of your application by pre-rendering the micro-frontend content at build time.
 
-```js
+```js filename="react-server.config.mjs"
 export default {
   export() {
     return [
@@ -133,6 +133,34 @@ export default {
         remote: true,
       }
     ];
+  },
+};
+```
+
+<Link name="static-export-outlets">
+## Static export outlets
+</Link>
+
+You can also export outlets as static. To do this, you can define your static path as an object with the `path` and `outlet` properties, where `path` is the route path and `outlet` is the name of the outlet. By using static export for outlets, you can improve the performance of your application by pre-rendering the outlet content at build time. Exported outlets will be rendered as RSC components. Client-side navigation to an exported outlet will use the static outlet content instead of making a request to the server.
+
+```js filename="react-server.config.mjs"
+export default {
+  export() {
+    return [{ path: "/photos/1", outlet: "modal" }];
+  },
+};
+```
+
+<Link name="disable-static-export-for-rsc-routes">
+## Disable static export for RSC routes
+</Link>
+
+You can disable static export for RSC routes by setting the `rsc` property to `false`. This is useful if you have a page that is an RSC route but you don't want to pre-render it at build time or you don't plan to use the RSC payload for that route. This will prevent the RSC payload from being generated at build time and the route will be rendered only as a regular HTML page to reduce the deployment size.
+
+```js filename="react-server.config.mjs"
+export default {
+  export() {
+    return [{ path: "/photos/1", rsc: false }];
   },
 };
 ```

--- a/packages/react-server-adapter-core/index.mjs
+++ b/packages/react-server-adapter-core/index.mjs
@@ -344,11 +344,8 @@ export function createAdapter({
     success(`${name} output successfully prepared.`);
 
     const files = {
-      static: () =>
-        getFiles(
-          ["**/*", "!**/*.html.gz", "!**/*.html.br", "!**/x-component.*"],
-          distDir
-        ),
+      static: () => getFiles(["**/*", "!**/*.gz", "!**/*.br"], distDir),
+      compressed: () => getFiles(["**/*.gz", "**/*.br"], distDir),
       assets: () => getFiles(["assets/**/*"], reactServerDir),
       client: () =>
         getFiles(["client/**/*", "!**/*-manifest.json"], reactServerDir),
@@ -374,6 +371,14 @@ export function createAdapter({
         copyFiles(
           "copying static files",
           await files.static(),
+          distDir,
+          out ?? outStaticDir,
+          reactServerDir
+        ),
+      compressed: async (out) =>
+        copyFiles(
+          "copying compressed files",
+          await files.compressed(),
           distDir,
           out ?? outStaticDir,
           reactServerDir

--- a/packages/react-server-adapter-vercel/index.mjs
+++ b/packages/react-server-adapter-vercel/index.mjs
@@ -62,6 +62,12 @@ export const adapter = createAdapter({
       version: 3,
       ...adapterOptions,
       routes: [
+        {
+          src: "/(.*)(@([^.]+)\\.)?(rsc|remote)\\.x-component$",
+          headers: {
+            "Content-Type": "text/x-component; charset=utf-8",
+          },
+        },
         { handle: "filesystem" },
         ...(adapterOptions?.routes ?? []),
         adapterOptions?.routes?.find((route) => route.status === 404) ?? {

--- a/packages/react-server/bin/commands/build.mjs
+++ b/packages/react-server/bin/commands/build.mjs
@@ -15,6 +15,7 @@ export default (cli) =>
     .option("--server", "[boolean] build server", { default: true })
     .option("--client", "[boolean] build client", { default: true })
     .option("--export", "[boolean] static export")
+    .option("--compression", "[boolean] enable compression", { default: false })
     .option("--adapter <adapter>", "[boolean|string] adapter", {
       default: "",
       type: [String],

--- a/packages/react-server/client/Link.jsx
+++ b/packages/react-server/client/Link.jsx
@@ -35,7 +35,18 @@ export default function Link({
     } catch (e) {
       onError?.(e);
     }
-  }, []);
+  }, [
+    to,
+    target,
+    local,
+    outlet,
+    root,
+    replace,
+    push,
+    rollback,
+    onNavigate,
+    onError,
+  ]);
 
   const handleNavigate = async (e) => {
     e.preventDefault();

--- a/packages/react-server/client/ReactServerComponent.jsx
+++ b/packages/react-server/client/ReactServerComponent.jsx
@@ -9,13 +9,7 @@ import {
   useClient,
 } from "./context.mjs";
 
-function FlightComponent({
-  standalone = false,
-  remote = false,
-  defer = false,
-  request,
-  children,
-}) {
+function FlightComponent({ remote = false, defer = false, request, children }) {
   const { url, outlet } = useContext(FlightContext);
   const client = useClient();
   const { registerOutlet, subscribe, getFlightResponse } = client;
@@ -24,7 +18,6 @@ function FlightComponent({
       (outlet === PAGE_ROOT || remote
         ? getFlightResponse?.(url, {
             outlet,
-            standalone,
             remote,
             defer,
             request,
@@ -39,7 +32,6 @@ function FlightComponent({
     const unsubscribe = subscribe(outlet || url, (to, options, callback) => {
       const nextComponent = getFlightResponse(to, {
         outlet,
-        standalone,
         remote,
         request,
       });
@@ -59,7 +51,7 @@ function FlightComponent({
       unregisterOutlet();
       unsubscribe();
     };
-  }, [url, outlet, standalone, remote, request, subscribe, getFlightResponse]);
+  }, [url, outlet, remote, request, subscribe, getFlightResponse]);
 
   useEffect(() => {
     if (children || (outlet !== PAGE_ROOT && Component)) {
@@ -71,7 +63,6 @@ function FlightComponent({
     if (remote || defer) {
       const nextComponent = getFlightResponse(url, {
         outlet,
-        standalone,
         remote,
         defer,
         request,
@@ -81,7 +72,7 @@ function FlightComponent({
         startTransition(() => setComponent(nextComponent));
       }
     }
-  }, [url, outlet, standalone, remote, defer, request, getFlightResponse]);
+  }, [url, outlet, remote, defer, request, getFlightResponse]);
 
   return (
     <ClientContext.Provider value={{ ...client, error }}>
@@ -93,7 +84,6 @@ function FlightComponent({
 export default function ReactServerComponent({
   url,
   outlet = null,
-  standalone,
   remote,
   defer,
   request,
@@ -101,12 +91,7 @@ export default function ReactServerComponent({
 }) {
   return (
     <FlightContext.Provider value={{ url, outlet }}>
-      <FlightComponent
-        standalone={standalone}
-        remote={remote}
-        defer={defer}
-        request={request}
-      >
+      <FlightComponent remote={remote} defer={defer} request={request}>
         {children}
       </FlightComponent>
     </FlightContext.Provider>

--- a/packages/react-server/lib/dev/ssr-handler.mjs
+++ b/packages/react-server/lib/dev/ssr-handler.mjs
@@ -5,6 +5,10 @@ import { forChild } from "../../config/index.mjs";
 import { context$, ContextStorage, getContext } from "../../server/context.mjs";
 import { createWorker } from "../../server/create-worker.mjs";
 import { init$ as module_loader_init$ } from "../../server/module-loader.mjs";
+import {
+  createRenderContext,
+  RENDER_TYPE,
+} from "../../server/render-context.mjs";
 import { getRuntime } from "../../server/runtime.mjs";
 import {
   ACTION_CONTEXT,
@@ -19,6 +23,7 @@ import {
   MEMORY_CACHE_CONTEXT,
   MODULE_LOADER,
   REDIRECT_CONTEXT,
+  RENDER_CONTEXT,
   RENDER_STREAM,
   SERVER_CONTEXT,
   STYLES_CONTEXT,
@@ -101,6 +106,10 @@ export default async function ssrHandler(root) {
               }
 
               await cache_init$?.();
+
+              const renderContext = createRenderContext(httpContext);
+              context$(RENDER_CONTEXT, renderContext);
+
               try {
                 const middlewares = await root_init$?.();
                 if (middlewares) {
@@ -118,15 +127,7 @@ export default async function ssrHandler(root) {
                 }
               }
 
-              const accept = httpContext.request.headers.get("accept");
-              if (
-                !accept ||
-                !(
-                  accept.includes("text/html") ||
-                  accept.includes("text/x-component") ||
-                  accept.includes("application/json")
-                )
-              ) {
+              if (renderContext.type === RENDER_TYPE.Unknown) {
                 return resolve();
               }
 

--- a/packages/react-server/lib/handlers/error.mjs
+++ b/packages/react-server/lib/handlers/error.mjs
@@ -6,9 +6,9 @@ import strip from "strip-ansi";
 import packageJson from "../../package.json" with { type: "json" };
 import { getContext } from "../../server/context.mjs";
 import {
-  HTTP_CONTEXT,
   HTTP_HEADERS,
   HTTP_STATUS,
+  RENDER_CONTEXT,
   SERVER_CONTEXT,
 } from "../../server/symbols.mjs";
 import { replaceError } from "../utils/error.mjs";
@@ -120,8 +120,8 @@ export default async function errorHandler(err) {
       return plainResponse(err);
     }
 
-    const accept = getContext(HTTP_CONTEXT)?.request?.headers?.get?.("accept");
-    if (accept?.includes?.(";standalone")) {
+    const renderContext = getContext(RENDER_CONTEXT);
+    if (renderContext?.flags?.isRSC) {
       return plainResponse(err);
     }
 

--- a/packages/react-server/lib/handlers/trailing-slash.mjs
+++ b/packages/react-server/lib/handlers/trailing-slash.mjs
@@ -1,6 +1,10 @@
 export default async function trailingSlash() {
-  return async ({ url: { pathname } }) => {
-    if (pathname !== "/" && pathname.endsWith("/")) {
+  return async ({ url: { pathname }, request: { method } }) => {
+    if (
+      pathname !== "/" &&
+      pathname.endsWith("/") &&
+      (method === "GET" || method === "HEAD")
+    ) {
       return new Response(null, {
         status: 301,
         headers: {

--- a/packages/react-server/lib/start/manifest.mjs
+++ b/packages/react-server/lib/start/manifest.mjs
@@ -107,7 +107,7 @@ export async function init$(type = "server", options = {}) {
         : (entry) => entry.src && id.endsWith(entry.src)
     );
     if (!clientEntry && !serverEntry) {
-      throw new Error(`Module not found: ${id}`);
+      throw new Error(`Module not found: ${$$id}`);
     }
     const specifier = __require.resolve(
       `./${outDir}/${(type === "client" ? clientEntry : serverEntry)?.file}`,

--- a/packages/react-server/server/RemoteComponent.jsx
+++ b/packages/react-server/server/RemoteComponent.jsx
@@ -11,14 +11,19 @@ async function RemoteComponentLoader({ url, ttl, request = {}, onError }) {
   const Component = await useCache(
     [url],
     async () => {
+      const src = new URL(url);
+      src.pathname =
+        `${src.pathname}/@${url.toString().replace(/[^a-zA-Z0-9_]/g, "_")}.remote.x-component`.replace(
+          /\/+/g,
+          "/"
+        );
       return createFromFetch(
-        fetch(url, {
+        fetch(src.toString(), {
           ...request,
           headers: {
             Origin: url.origin,
             ...request.headers,
-            Accept: "text/html;remote",
-            "React-Server-Outlet": url.toString(),
+            Accept: "text/html",
           },
         }).catch((e) => {
           (onError ?? getContext(LOGGER_CONTEXT)?.error)?.(e);

--- a/packages/react-server/server/Route.jsx
+++ b/packages/react-server/server/Route.jsx
@@ -1,5 +1,5 @@
 import { context$, getContext } from "@lazarv/react-server/server/context.mjs";
-import { useRequest, useUrl } from "@lazarv/react-server/server/request.mjs";
+import { useUrl } from "@lazarv/react-server/server/request.mjs";
 import { ROUTE_MATCH } from "@lazarv/react-server/server/symbols.mjs";
 import { match } from "@lazarv/react-server/server/route-match.mjs";
 
@@ -23,23 +23,14 @@ export default function Route({
   matchers,
   element,
   render,
-  standalone,
   fallback,
   children,
 }) {
-  const { headers } = useRequest();
   const params = useMatch(path, { exact, matchers, fallback });
 
   if (!params) return null;
+  context$(ROUTE_MATCH, params);
 
-  if (standalone !== false) {
-    context$(ROUTE_MATCH, params);
-  }
-
-  const accept = headers.get("accept");
-  const acceptStandalone = accept?.includes(";standalone");
-
-  if (acceptStandalone && standalone === false) return <>{children}</>;
   if (render) return render({ ...params, children });
   return element ?? <>{children}</>;
 }

--- a/packages/react-server/server/cache.mjs
+++ b/packages/react-server/server/cache.mjs
@@ -1,6 +1,6 @@
 import { getContext } from "@lazarv/react-server/server/context.mjs";
 
-import { useOutlet, useRequest, useUrl } from "./request.mjs";
+import { useOutlet, useUrl } from "./request.mjs";
 import { CACHE_CONTEXT, FLIGHT_CACHE, HTML_CACHE } from "./symbols.mjs";
 
 export function withCache(Component, ttl = Infinity) {
@@ -12,13 +12,12 @@ export function withCache(Component, ttl = Infinity) {
 
 export function useResponseCache(ttl = Infinity) {
   const url = useUrl();
-  const accept = useRequest()?.headers?.get?.("accept");
   const outlet = useOutlet();
   const cache = getContext(CACHE_CONTEXT);
   if (ttl === true) {
     ttl = Infinity;
   }
   const expiry = Date.now() + ttl;
-  cache.setExpiry([url, accept, outlet, FLIGHT_CACHE], expiry);
-  cache.setExpiry([url, accept, outlet, HTML_CACHE], expiry);
+  cache.setExpiry([url, "text/x-component", outlet, FLIGHT_CACHE], expiry);
+  cache.setExpiry([url, "text/html", outlet, HTML_CACHE], expiry);
 }

--- a/packages/react-server/server/render-context.mjs
+++ b/packages/react-server/server/render-context.mjs
@@ -1,0 +1,43 @@
+export const RENDER_TYPE = {
+  Unknown: "unknown",
+  RSC: "rsc",
+  Remote: "remote",
+  HTML: "html",
+};
+
+export function createRenderContext(httpContext) {
+  const { pathname } = httpContext.url;
+
+  const match = pathname.match(
+    /(@(?<outlet>[^.]+)\.)?(?<type>rsc|remote)\.x-component$/
+  );
+
+  const context = {
+    type: RENDER_TYPE.Unknown,
+    outlet: null,
+  };
+  if (!match) {
+    context.type = httpContext.request.headers
+      .get("accept")
+      ?.includes("text/html")
+      ? RENDER_TYPE.HTML
+      : RENDER_TYPE.Unknown;
+  } else {
+    const { outlet, type } = match.groups;
+    context.type = RENDER_TYPE.RSC;
+    context.outlet = outlet ?? null;
+    context.remote = type === RENDER_TYPE.Remote;
+
+    httpContext.url.pathname = pathname.replace(match[0], "");
+  }
+
+  return {
+    ...context,
+    url: httpContext.url,
+    flags: {
+      isRSC: context.type === RENDER_TYPE.RSC,
+      isHTML: context.type === RENDER_TYPE.HTML,
+      isRemote: context.remote ?? false,
+    },
+  };
+}

--- a/packages/react-server/server/request.mjs
+++ b/packages/react-server/server/request.mjs
@@ -3,6 +3,7 @@ import {
   FORM_DATA_PARSER,
   HTTP_CONTEXT,
   HTTP_OUTLET,
+  RENDER_CONTEXT,
 } from "@lazarv/react-server/server/symbols.mjs";
 
 export function useHttpContext() {
@@ -79,9 +80,10 @@ export function rewrite(pathname) {
 export function useOutlet() {
   return decodeURIComponent(
     getContext(HTTP_OUTLET) ??
+      getContext(RENDER_CONTEXT)?.outlet ??
       getContext(HTTP_CONTEXT)?.request?.headers?.get("react-server-outlet") ??
       "PAGE_ROOT"
-  );
+  ).replace(/[^a-zA-Z0-9_]/g, "_");
 }
 
 export function outlet(target) {

--- a/packages/react-server/server/router.d.ts
+++ b/packages/react-server/server/router.d.ts
@@ -9,7 +9,6 @@ export type RouteMatchers = Record<string, (value: string) => boolean>;
  * @property matchers - Custom matchers for route parameters
  * @property element - The element to render for the route
  * @property render - A function that returns the element to render for the route
- * @property standalone - If true, the route is standalone, only rendered when client requests a full page reload
  * @property fallback - If true, the route is a fallback route
  *
  * @example
@@ -34,7 +33,6 @@ export const Route: React.FC<
     render?: (
       props: React.PropsWithChildren<RouteParams>
     ) => React.ReactElement;
-    standalone?: boolean;
     fallback?: boolean;
   }>
 >;

--- a/packages/react-server/server/symbols.mjs
+++ b/packages/react-server/server/symbols.mjs
@@ -25,6 +25,7 @@ export const BUILD_OPTIONS = Symbol.for("BUILD_OPTIONS");
 export const ACTION_CONTEXT = Symbol.for("ACTION_CONTEXT");
 export const RELOAD = Symbol.for("RELOAD");
 export const RENDER_STREAM = Symbol.for("RENDER_STREAM");
+export const RENDER_CONTEXT = Symbol.for("RENDER_CONTEXT");
 export const WORKER_THREAD = Symbol.for("WORKER_THREAD");
 export const PRELUDE_HTML = Symbol.for("PRELUDE_HTML");
 export const POSTPONE_STATE = Symbol.for("POSTPONE_STATE");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,7 +127,7 @@ importers:
         version: 1.0.12(next@14.2.8(@babel/core@7.24.7)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)(sass@1.77.6))(react@19.0.0-rc-a7d1240c-20240731)
       '@vitejs/plugin-react-swc':
         specifier: ^3.7.0
-        version: 3.7.0(@swc/helpers@0.5.5)(vite@6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.45))(terser@5.31.1))
+        version: 3.7.0(@swc/helpers@0.5.5)(vite@6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.39))(terser@5.31.1))
       algoliasearch:
         specifier: ^4.24.0
         version: 4.24.0
@@ -148,14 +148,14 @@ importers:
         version: 4.0.0
       vite-plugin-svgr:
         specifier: ^4.2.0
-        version: 4.2.0(rollup@4.24.0)(typescript@5.6.3)(vite@6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.45))(terser@5.31.1))
+        version: 4.2.0(rollup@4.24.0)(typescript@5.6.3)(vite@6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.39))(terser@5.31.1))
     devDependencies:
       '@types/react':
         specifier: ^18.3.2
         version: 18.3.3
       autoprefixer:
         specifier: ^10.4.19
-        version: 10.4.19(postcss@8.4.45)
+        version: 10.4.19(postcss@8.4.39)
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
@@ -12193,10 +12193,10 @@ snapshots:
       next: 14.2.8(@babel/core@7.24.7)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)(sass@1.77.6)
       react: 19.0.0-rc-a7d1240c-20240731
 
-  '@vitejs/plugin-react-swc@3.7.0(@swc/helpers@0.5.5)(vite@6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.45))(terser@5.31.1))':
+  '@vitejs/plugin-react-swc@3.7.0(@swc/helpers@0.5.5)(vite@6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.39))(terser@5.31.1))':
     dependencies:
       '@swc/core': 1.6.6(@swc/helpers@0.5.5)
-      vite: 6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.45))(terser@5.31.1)
+      vite: 6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.39))(terser@5.31.1)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -12598,16 +12598,6 @@ snapshots:
       normalize-range: 0.1.2
       picocolors: 1.0.1
       postcss: 8.4.39
-      postcss-value-parser: 4.2.0
-
-  autoprefixer@10.4.19(postcss@8.4.45):
-    dependencies:
-      browserslist: 4.23.1
-      caniuse-lite: 1.0.30001638
-      fraction.js: 4.3.7
-      normalize-range: 0.1.2
-      picocolors: 1.0.1
-      postcss: 8.4.45
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -17923,12 +17913,12 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-svgr@4.2.0(rollup@4.24.0)(typescript@5.6.3)(vite@6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.45))(terser@5.31.1)):
+  vite-plugin-svgr@4.2.0(rollup@4.24.0)(typescript@5.6.3)(vite@6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.39))(terser@5.31.1)):
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.24.0)
       '@svgr/core': 8.1.0(typescript@5.6.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.6.3))
-      vite: 6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.45))(terser@5.31.1)
+      vite: 6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.39))(terser@5.31.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -17961,6 +17951,20 @@ snapshots:
       sass: 1.77.6
       stylus: 0.62.0
       sugarss: 4.0.1(postcss@8.4.45)
+      terser: 5.31.1
+
+  vite@6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.39))(terser@5.31.1):
+    dependencies:
+      esbuild: 0.21.3
+      postcss: 8.4.45
+      rollup: 4.24.0
+    optionalDependencies:
+      '@types/node': 20.14.9
+      fsevents: 2.3.3
+      less: 4.2.0
+      sass: 1.77.6
+      stylus: 0.62.0
+      sugarss: 4.0.1(postcss@8.4.39)
       terser: 5.31.1
 
   vite@6.0.0-alpha.18(@types/node@20.14.9)(less@4.2.0)(sass@1.77.6)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.4.45))(terser@5.31.1):


### PR DESCRIPTION
This PR fixes issues around static generated RSC x-component files and how response type selection works to send an RSC payload. The response type selection needs to be on par with the static generation to maintain the same solution for both static and dynamic rendering.

Changes request payload to select RSC rendering. Instead of using HTTP headers, the framework now uses an URL pathname suffix, including outlet name and remote or standard RSC rendering and static generation uses the same format in filenames. This fixes #95.

Adds build options to enable compression (GZip and Brotli) and opt-out of static RSC rendering, see more about this in the updated docs.

Adds static export option to render a single outlet. This is mainly to keep consistency with the URL format right now, but might be a useful feature for SSG.

Updates the deployment Adapter API to not copy compressed files by default, but copy static RSC files and also the Vercel adapter to add the necessary 
`Content-Type` header for static `.x-component` files. This fixes #94.

Removes the `standalone` route option and mode as it was not really useful and there are other ways to achieve the same functionality.

