### PR TITLE
fix: handling deploy cli argument in build action adapter handler

### DIFF
--- a/docs/src/pages/en/(pages)/deploy/api.mdx
+++ b/docs/src/pages/en/(pages)/deploy/api.mdx
@@ -55,7 +55,26 @@ You need to pass adapter properties to the `createAdapter` function to configure
 
 `handler`: The adapter handler function.
 
-`deploy`: The deployment command and arguments. This is optional. When provided, the adapter will show what command the developer needs to run to deploy the application after it has been built. If the `--deploy` flag is provided during the build, the adapter will run this command.
+`deploy`: The deployment command and arguments. This is optional. When provided, the adapter will show what command the developer needs to run to deploy the application after it has been built. If the `--deploy` flag is provided during the build, the adapter will run this command. The `deploy` property can also be a function that will be called with the adapter options, CLI options and the handler result. This is useful if you need to customize the deployment command based on the adapter options or the handler result. If you don't provide a result with `command` and `args`, the default deployment handling spawning the command will be skipped. This is useful if you want to implement a custom deployment workflow in the adapter.
+
+```js
+export const adapter = createAdapter({
+  // ...
+  handler: async ({ adapterOptions, files, copy, config, reactServerDir, reactServerOutDir, root, options }) => {
+    // Your adapter handler implementation
+    return {
+      // Your handler result, this will be passed to the deploy function
+    };
+  },
+  async deploy({ adapterOptions, options, handlerResult }) {
+    // customize the deployment command based on the adapter options, CLI options or handler result
+    return {
+      command: "vercel",
+      args: ["deploy", "--prebuilt"],
+    };
+  },
+});
+```
 
 <Link name="adapter-handler">
 ## Adapter handler

--- a/packages/react-server-adapter-core/index.d.ts
+++ b/packages/react-server-adapter-core/index.d.ts
@@ -3,7 +3,13 @@ declare module "@lazarv/react-server-adapter-core" {
     (adapterOptions: T, root: string, options: any): Promise<void>;
   }
 
-  export function createAdapter<T = any>(options: {
+  export type DeployCommandDescriptor = {
+    command: string;
+    args: string[];
+    message?: string;
+  };
+
+  export function createAdapter<T = any, R = void>(options: {
     name: string;
     outDir: string;
     outStaticDir?: string;
@@ -32,8 +38,19 @@ declare module "@lazarv/react-server-adapter-core" {
       reactServerDir: string;
       reactServerOutDir: string;
       root: string;
-      options: any;
-    }) => Promise<void>;
+      options: Record<string, any>;
+    }) => Promise<R>;
+    deploy:
+      | DeployCommandDescriptor
+      | ((context: {
+          adapterOptions: T;
+          options: Record<string, any>;
+          handlerResult: R;
+        }) =>
+          | DeployCommandDescriptor
+          | Promise<DeployCommandDescriptor>
+          | void
+          | Promise<void>);
   }): Adapter<T>;
 
   export function banner(message: string): void;

--- a/packages/react-server-adapter-core/index.mjs
+++ b/packages/react-server-adapter-core/index.mjs
@@ -446,7 +446,7 @@ export function createAdapter({
       await copy.server();
     }
 
-    await handler({
+    const handlerResult = await handler({
       files,
       copy,
       config,
@@ -458,17 +458,23 @@ export function createAdapter({
     });
 
     success(`${name} deployment successfully created.`);
-    if (deploy && deploy.command && deploy.args) {
-      if (options.deploy) {
-        banner(`deploying to ${name}`);
-        clearProgress();
-        await spawnCommand(deploy.command, deploy.args);
-      } else {
-        console.log(
-          `${colors.gray(`Deploy to ${name} using:`)} ${deploy.command} ${deploy.args.join(" ")}`
-        );
-        if (deploy.message) {
-          console.log(deploy.message);
+    if (deploy) {
+      const { command, args, message } =
+        typeof deploy === "function"
+          ? await deploy({ adapterOptions, options, handlerResult })
+          : deploy;
+      if (command && args) {
+        if (options.deploy) {
+          banner(`deploying to ${name}`);
+          clearProgress();
+          await spawnCommand(command, args);
+        } else {
+          console.log(
+            `${colors.gray(`Deploy to ${name} using:`)} ${command} ${args.join(" ")}`
+          );
+          if (message) {
+            console.log(message);
+          }
         }
       }
     }

--- a/packages/react-server/lib/build/adapter.mjs
+++ b/packages/react-server/lib/build/adapter.mjs
@@ -15,7 +15,9 @@ export default async function adapter(root, options) {
   const adapter =
     options?.adapter?.[0] === "false"
       ? null
-      : options.adapter || config.adapter;
+      : typeof options.adapter?.[0] === "string" && options.adapter?.[0]
+        ? options.adapter?.[0]
+        : config.adapter;
   if (adapter) {
     if (typeof adapter === "function") {
       return await adapter({}, root, options);


### PR DESCRIPTION
Fixes handling the `deploy` CLI argument in the build action adapter handler addressing #101.

Adds handling `deploy` property of an adapter implementation when the value of `deploy` is a function. See more in the docs at https://react-server.dev/deploy/api#define-the-adapter-handler. Implements feature request at https://github.com/lazarv/react-server/pull/48#issuecomment-2552492407