### PR TITLE
fix: builtin module import

### DIFF
--- a/test/__test__/basic.spec.mjs
+++ b/test/__test__/basic.spec.mjs
@@ -270,3 +270,11 @@ test("suspense client", async () => {
     expect(await scripts[3].getAttribute("src")).toBe(null);
   }
 });
+
+test("resolve builtin module import", async () => {
+  await server("fixtures/builtin-import.jsx");
+  await page.goto(hostname);
+  expect(await page.textContent("body")).toContain(
+    "react/react.react-server.js"
+  );
+});

--- a/test/fixtures/builtin-import.jsx
+++ b/test/fixtures/builtin-import.jsx
@@ -3,5 +3,5 @@ import { createRequire } from "module";
 const _require = createRequire(import.meta.url);
 
 export default function Builtin() {
-  return <>{_require.resolve("react")}</>;
+  return <>{_require.resolve("react").replace(/\\/g, "/")}</>;
 }

--- a/test/fixtures/builtin-import.jsx
+++ b/test/fixtures/builtin-import.jsx
@@ -1,0 +1,7 @@
+import { createRequire } from "module";
+
+const _require = createRequire(import.meta.url);
+
+export default function Builtin() {
+  return <>{_require.resolve("react")}</>;
+}


### PR DESCRIPTION
This PR fixes built-in module import when not using the `node:` protocol for the built-in module, like `import { ... } from "module";` instead of `import { ... } from "node:module";`.