### PR TITLE
docs(ja): improve readability of the guide documentation  Guide(index)

### DIFF
--- a/docs/src/pages/ja/guide.(index).mdx
+++ b/docs/src/pages/ja/guide.(index).mdx
@@ -1,3 +1,13 @@
-import Page from "../en/guide.(index).mdx";
+# ガイド
 
-<Page />
+このセクションでは、`@lazarv/react-server` の使い方を説明します。もしあなたが`@lazarv/react-server`を初めて使うのであれば、[さあ始めよう](/guide/get-started)から始めてください。特定のトピックを探している場合は、ページ上部の検索バーを使ってください。お探しのトピックが見つからない場合は、GitHubにIssueを出してください。喜んでお手伝いします！
+
+このスタートガイドでは、`@lazarv/react-server`を使った最初のアプリケーションを作成する方法を紹介します。非常にシンプルなアプリケーションを作成し、開発モードと本番モードで実行する方法を学びます。また、アプリケーションを本番用に構築する方法も学びます。
+
+[なぜ`@lazarv/react-server`なのか？ ](/guide/why) では`@lazarv/react-server`をを使うことの利点と、なぜ次のプロジェクトで使うことを検討すべきなのかについて学びます。
+
+次に、Reactサーバーサイドレンダリングの3つの柱について説明します。[React Server Components](/guide/server-components)の作成方法、インタラクティブな[クライアントコンポーネント](/guide/client-components)の作成方法、サーバーと対話するための[Server Functions](/guide/server-functions)の作成方法を学びます。
+
+より高度なトピックをお探しの場合は、チュートリアルのセクションをご覧ください。ここでは、`@lazarve/react-server`を使って様々なアプリケーションを構築する方法をステップバイステップで紹介しています。[Hello World](/tutorials/hello-world)アプリケーションの作成方法、Server Functionsを使ったシンプルな[Todo](/tutorials/todo-app)アプリケーションの作成方法、クライアントコンポーネントを使用した[フォトギャラリー](/tutorials/photos)アプリケーションの作成方法を学ぶことができます。
+
+React Server Components、Server Functions、ディレクティブの詳細については、Reactチームが提供する<a href="https://react.dev/reference/rsc/server-components" target="_blank">React Server Components</a>ドキュメントをご覧ください。


### PR DESCRIPTION
# Improve Japanese documentation readability

This PR improves the readability of the Japanese guide documentation.

## Changes
- Revise Japanese expressions in `docs/src/pages/ja/guide.mdx`
 - Enhance natural Japanese phrasing
 - Standardize technical term translations

## Review Notes
Japanese native team members have reviewed and confirmed:
- Natural Japanese language flow
- Appropriate technical terminology

This is a documentation-only change with no impact on functionality.