### PR TITLE
fix: cli build eval and clear screen

### DIFF
--- a/packages/react-server/bin/commands/build.mjs
+++ b/packages/react-server/bin/commands/build.mjs
@@ -21,6 +21,7 @@ export default (cli) =>
       type: [String],
     })
     .option("--deploy", "[boolean] deploy using adapter", { default: false })
+    .option("-e, --eval <code>", "evaluate code", { type: "string" })
     .option("--outDir <dir>", "[string] output directory", {
       default: ".react-server",
     })

--- a/packages/react-server/lib/build/server.mjs
+++ b/packages/react-server/lib/build/server.mjs
@@ -31,7 +31,9 @@ const __require = createRequire(import.meta.url);
 const cwd = sys.cwd();
 
 export default async function serverBuild(root, options) {
-  root ||= "@lazarv/react-server/file-router";
+  if (!options.eval) {
+    root ||= "@lazarv/react-server/file-router";
+  }
 
   banner("rsc", options.dev);
   const config = forRoot();
@@ -262,10 +264,7 @@ export default async function serverBuild(root, options) {
             { paths: [cwd] }
           ),
           "server/index":
-            !root &&
-            (!reactServerRouterModule ||
-              options.eval ||
-              (!process.stdin.isTTY && !process.env.CI))
+            !root && (options.eval || (!process.stdin.isTTY && !process.env.CI))
               ? "virtual:react-server-eval.jsx"
               : root?.startsWith("virtual:")
                 ? root

--- a/packages/react-server/lib/dev/action.mjs
+++ b/packages/react-server/lib/dev/action.mjs
@@ -18,6 +18,7 @@ import {
 } from "../../server/symbols.mjs";
 import { getEnv } from "../sys.mjs";
 import banner from "../utils/banner.mjs";
+import { clearScreen } from "../utils/clear-screen.mjs";
 import { formatDuration } from "../utils/format.mjs";
 import getServerAddresses from "../utils/server-address.mjs";
 import { command } from "./command.mjs";
@@ -25,6 +26,10 @@ import createServer from "./create-server.mjs";
 
 export default async function dev(root, options) {
   try {
+    if (options.clearScreen) {
+      clearScreen();
+    }
+
     await logo();
     banner("starting development server");
 

--- a/packages/react-server/lib/dev/create-server.mjs
+++ b/packages/react-server/lib/dev/create-server.mjs
@@ -130,7 +130,6 @@ export default async function createServer(root, options) {
     publicDir: join(cwd, publicDir),
     root: cwd,
     appType: "custom",
-    clearScreen: options.clearScreen,
     configFile: false,
     optimizeDeps: {
       holdUntilCrawlEnd: true,

--- a/packages/react-server/lib/utils/clear-screen.mjs
+++ b/packages/react-server/lib/utils/clear-screen.mjs
@@ -1,0 +1,10 @@
+import readline from "node:readline";
+
+export function clearScreen() {
+  if (!process.stdout.isTTY || process.env.CI) return;
+  const repeatCount = process.stdout.rows - 2;
+  const blank = repeatCount > 0 ? "\n".repeat(repeatCount) : "";
+  console.log(blank);
+  readline.cursorTo(process.stdout, 0, 0);
+  readline.clearScreenDown(process.stdout);
+}


### PR DESCRIPTION
Support `--eval` to build a production app:

```sh
npx @lazarv/react-server build -e 'export default function App(){ return <h1>Hello World</h1>; }'
```

Fix `--clear-screen` to properly clear the screen when using the development server.