### PR TITLE
fix: terminate worker on static export skip

### DIFF
--- a/packages/react-server/lib/build/static.mjs
+++ b/packages/react-server/lib/build/static.mjs
@@ -125,6 +125,7 @@ export default async function staticSiteGenerator(root, options) {
 
       if (paths.length === 0) {
         console.log(colors.yellow("warning: no paths to export, skipping..."));
+        getRuntime(WORKER_THREAD)?.terminate();
         return;
       }
 
@@ -420,10 +421,7 @@ export default async function staticSiteGenerator(root, options) {
           })
       );
 
-      const worker = getRuntime(WORKER_THREAD);
-      if (worker) {
-        worker.terminate();
-      }
+      getRuntime(WORKER_THREAD)?.terminate();
     }
   });
 }


### PR DESCRIPTION
Terminate worker when there's no route/path to use at static export, fixing the hanging CLI process.
Addresses #157 