### PR TITLE
fix: revert vite cors config

### DIFF
--- a/packages/react-server/lib/dev/create-server.mjs
+++ b/packages/react-server/lib/dev/create-server.mjs
@@ -105,7 +105,7 @@ export default async function createServer(root, options) {
     server: {
       ...config.server,
       middlewareMode: true,
-      cors: options.cors ?? config.server?.cors ?? config?.cors ?? false,
+      cors: false,
       hmr:
         config.server?.hmr === false
           ? false


### PR DESCRIPTION
Reverts Vite CORS config to force disable it, as enabling CORS on the Vite development server was interfering with calling server functions when using a `RemoteComponent`