### PR TITLE
fix(docs): modify router-docs order number

### DIFF
--- a/docs/src/pages/en/(pages)/router/api.mdx
+++ b/docs/src/pages/en/(pages)/router/api.mdx
@@ -1,7 +1,7 @@
 ---
 title: API routes
 category: Router
-order: 8
+order: 9
 ---
 
 import Link from "../../../../components/Link.jsx";

--- a/docs/src/pages/en/(pages)/router/configuration.mdx
+++ b/docs/src/pages/en/(pages)/router/configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuration
 category: Router
-order: 10
+order: 11
 ---
 
 import Link from "../../../../components/Link.jsx";

--- a/docs/src/pages/en/(pages)/router/markdown.mdx
+++ b/docs/src/pages/en/(pages)/router/markdown.mdx
@@ -1,7 +1,7 @@
 ---
 title: Markdown
 category: Router
-order: 6
+order: 7
 ---
 
 import Link from "../../../../components/Link.jsx";

--- a/docs/src/pages/en/(pages)/router/middlewares.mdx
+++ b/docs/src/pages/en/(pages)/router/middlewares.mdx
@@ -1,7 +1,7 @@
 ---
 title: Middlewares
 category: Router
-order: 7
+order: 8
 ---
 
 import Link from "../../../../components/Link.jsx";

--- a/docs/src/pages/en/(pages)/router/static.page.mdx
+++ b/docs/src/pages/en/(pages)/router/static.page.mdx
@@ -1,7 +1,7 @@
 ---
 title: Static generation
 category: Router
-order: 9
+order: 10
 ---
 
 import Link from "../../../../components/Link.jsx";


### PR DESCRIPTION
fixed the duplicate order number in the "router" section of the documentation
