### PR TITLE
fix(docs): fix typo in documentation

### DIFF
--- a/docs/src/pages/ja/(pages)/guide/why.mdx
+++ b/docs/src/pages/ja/(pages)/guide/why.mdx
@@ -5,7 +5,7 @@ order: 2
 
 import Link from "../../../../components/Link.jsx";
 
-# なぜreact-serverを使うべきか?`?
+# なぜreact-serverを使うべきか?
 
 ここでは次の質問に答えることとしましょう: なぜ `@lazarv/react-serverを使うべきか?`願わくはあなたがなぜこのフレームワークを利用すべきか、そしてこのフレームワークを次のプロジェクトで利用することが良い選択であることの答えを手に入れられるでしょう。
 


### PR DESCRIPTION
This commit fixes a typo in the documentation where an extra '?' was present.
