### PR TITLE
fix(docs): add title link in todo tutorials doc

### DIFF
--- a/docs/src/pages/en/(pages)/tutorials/todo-app.mdx
+++ b/docs/src/pages/en/(pages)/tutorials/todo-app.mdx
@@ -167,7 +167,9 @@ The Item component will render our Todo item using an `id` and `title` prop. But
 
 The framework will resolve this `$ACTION_ID_` prefixed path to the server function and it will call our server function function!
 
+<Link name="server-functions">
 ## Server functions
+</Link>
 
 We will use server functions to implement all functionality of our Todo app. This is the most complex part of the app, but don’t shy away, it’s still really very simple, let’s create **src/actions.ts**:
 


### PR DESCRIPTION
Fixed missing link in TODO tutorial title
