### PR TITLE
fix: handle server function not found

### DIFF
--- a/examples/todo/src/AddTodo.tsx
+++ b/examples/todo/src/AddTodo.tsx
@@ -37,7 +37,7 @@ export default function AddTodo() {
       )) ??
         (error && (
           <p className="bg-red-50 border rounded-lg border-red-500 text-red-500 p-2.5">
-            {error}
+            {error?.toString()}
           </p>
         ))}
     </form>

--- a/packages/react-server/lib/dev/create-server.mjs
+++ b/packages/react-server/lib/dev/create-server.mjs
@@ -622,7 +622,7 @@ export default async function createServer(root, options) {
         const filename = context.url.searchParams.get("filename");
         const mod =
           viteDevServer.environments.rsc.moduleGraph.getModuleById(filename);
-        if (mod) {
+        if (mod?.transformResult?.map) {
           return new Response(
             JSON.stringify({
               ...mod.transformResult.map,

--- a/packages/react-server/server/action-state.mjs
+++ b/packages/react-server/server/action-state.mjs
@@ -1,5 +1,14 @@
 import { getContext } from "./context.mjs";
-import { ACTION_CONTEXT } from "./symbols.mjs";
+import { ACTION_CONTEXT, SERVER_FUNCTION_NOT_FOUND } from "./symbols.mjs";
+
+export class ServerFunctionNotFoundError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = SERVER_FUNCTION_NOT_FOUND;
+    this.message = message;
+    this.stack = new Error().stack;
+  }
+}
 
 export function useActionState(action) {
   const { formData, data, error, actionId } = getContext(ACTION_CONTEXT) ?? {
@@ -8,7 +17,7 @@ export function useActionState(action) {
     error: null,
     actionId: null,
   };
-  if (actionId !== action.$$id) {
+  if (actionId !== action.$$id && error?.name !== SERVER_FUNCTION_NOT_FOUND) {
     return {
       formData: null,
       data: null,

--- a/packages/react-server/server/module-loader.mjs
+++ b/packages/react-server/server/module-loader.mjs
@@ -1,7 +1,6 @@
 import { createRequire } from "node:module";
 
-import { redirect } from "./redirects.mjs";
-import { useUrl } from "./request.mjs";
+import { ServerFunctionNotFoundError } from "./action-state.mjs";
 
 const __require = createRequire(import.meta.url);
 
@@ -28,7 +27,9 @@ export async function init$(
               const action = (await mod)[prop];
               try {
                 if (!action) {
-                  redirect(useUrl().pathname);
+                  return {
+                    error: new ServerFunctionNotFoundError(),
+                  };
                 }
                 return { data: await action(...args), actionId: action.$$id };
               } catch (e) {

--- a/packages/react-server/server/render-rsc.jsx
+++ b/packages/react-server/server/render-rsc.jsx
@@ -188,7 +188,7 @@ export async function render(Component, props = {}, options = {}) {
 
           const { data, actionId, error } = await action();
 
-          if (error.name === SERVER_FUNCTION_NOT_FOUND) {
+          if (error?.name === SERVER_FUNCTION_NOT_FOUND) {
             const e = new Error("Server Function Not Found");
             e.digest = e.message;
             throw e;

--- a/packages/react-server/server/render-rsc.jsx
+++ b/packages/react-server/server/render-rsc.jsx
@@ -43,7 +43,9 @@ import {
   RENDER_STREAM,
   RENDER_WAIT,
   STYLES_CONTEXT,
+  SERVER_FUNCTION_NOT_FOUND,
 } from "@lazarv/react-server/server/symbols.mjs";
+import { ServerFunctionNotFoundError } from "./action-state.mjs";
 
 const serverReferenceMap = new Proxy(
   {},
@@ -97,7 +99,7 @@ export async function render(Component, props = {}, options = {}) {
           !options.skipFunction
         ) {
           let action = async function () {
-            throw new Error("Server action not found");
+            throw new ServerFunctionNotFoundError();
           };
           let input = [];
           if (isFormData) {
@@ -149,9 +151,15 @@ export async function render(Component, props = {}, options = {}) {
               serverActionHeader.split("#");
             action = async () => {
               try {
-                const data = await (
-                  await globalThis.__webpack_require__(serverReferenceModule)
-                )[serverReferenceName].bind(null, ...input)();
+                const mod = await globalThis.__webpack_require__(
+                  serverReferenceModule
+                );
+                const fn = mod[serverReferenceName];
+                if (typeof fn !== "function") {
+                  throw new ServerFunctionNotFoundError();
+                }
+                const boundFn = fn.bind(null, ...input);
+                const data = await boundFn();
                 return {
                   data,
                   actionId: serverActionHeader,
@@ -179,6 +187,12 @@ export async function render(Component, props = {}, options = {}) {
           }
 
           const { data, actionId, error } = await action();
+
+          if (error.name === SERVER_FUNCTION_NOT_FOUND) {
+            const e = new Error("Server Function Not Found");
+            e.digest = e.message;
+            throw e;
+          }
 
           callServer = true;
           if (!isFormData) {
@@ -223,7 +237,7 @@ export async function render(Component, props = {}, options = {}) {
           context$(ACTION_CONTEXT, {
             formData: input[input.length - 1] ?? input,
             data,
-            error,
+            error: redirect?.response ? null : error,
             actionId,
           });
         }

--- a/packages/react-server/server/symbols.mjs
+++ b/packages/react-server/server/symbols.mjs
@@ -40,3 +40,6 @@ export const POSTPONE_STATE = Symbol.for("POSTPONE_STATE");
 export const IMPORT_MAP = Symbol.for("IMPORT_MAP");
 export const CACHE_MISS = Symbol.for("CACHE_MISS");
 export const CACHE_KEY = Symbol.for("CACHE_KEY");
+export const SERVER_FUNCTION_NOT_FOUND = Symbol.for(
+  "SERVER_FUNCTION_NOT_FOUND"
+);


### PR DESCRIPTION
This PR changes how missing server functions are handled. Instead of redirecting, a missing server function throws an error, which can be captured using a `useActionState` during server-side rendering and can also be captured using an error component or an error boundary to pass control to the developer on how to handle the issue.