### PR TITLE
fix: handle unhandled rejection

### DIFF
--- a/packages/react-server/lib/dev/action.mjs
+++ b/packages/react-server/lib/dev/action.mjs
@@ -33,6 +33,16 @@ export default async function dev(root, options) {
     await logo();
     banner("starting development server");
 
+    process.on("unhandledRejection", (err) => {
+      const logger = getRuntime(LOGGER_CONTEXT);
+      logger?.error?.(
+        `${colors.red("✖")} ${colors.bold("Unhandled Rejection:")} ${err?.message ?? err}`
+      );
+      if (err?.stack) {
+        logger?.error?.(colors.red(err.stack));
+      }
+    });
+
     let server;
     let configWatcher;
     let showHelp = true;

--- a/packages/react-server/lib/start/action.mjs
+++ b/packages/react-server/lib/start/action.mjs
@@ -4,10 +4,15 @@ import { isIPv6 } from "node:net";
 import { availableParallelism } from "node:os";
 
 import { loadConfig } from "../../config/prebuilt.mjs";
-import { init$ as runtime_init$, runtime$ } from "../../server/runtime.mjs";
+import {
+  getRuntime,
+  init$ as runtime_init$,
+  runtime$,
+} from "../../server/runtime.mjs";
 import {
   CONFIG_CONTEXT,
   CONFIG_ROOT,
+  LOGGER_CONTEXT,
   SERVER_CONTEXT,
 } from "../../server/symbols.mjs";
 import { formatDuration } from "../utils/format.mjs";
@@ -98,6 +103,10 @@ export default async function start(root, options) {
         });
         process.on("SIGTERM", () => {
           process.exit(0);
+        });
+        process.on("unhandledRejection", (reason) => {
+          const logger = getRuntime(LOGGER_CONTEXT);
+          logger.error(reason);
         });
 
         worker(root, options, config);


### PR DESCRIPTION
Handle an `unhandledRejection` error, causing both the development and production servers to exit. This PR changes the behavior to log the error but prevents the server from exiting.