### PR TITLE
docs(en): fix setup command in tutorial

### DIFF
--- a/docs/src/pages/en/(pages)/tutorials/photos.mdx
+++ b/docs/src/pages/en/(pages)/tutorials/photos.mdx
@@ -25,8 +25,8 @@ mkdir photos
 cd photos
 pnpm init
 pnpm add @lazarv/react-server react-click-away-listener @faker-js/faker
-pnpm add -D @types/react @types/react-dom autoprefixer postcss tailwindcss typescript typescript-plugin-css-modules
-pnpx tailwindcss init -p
+pnpm add -D @types/react @types/react-dom autoprefixer postcss tailwindcss@3 typescript typescript-plugin-css-modules
+pnpx tailwindcss@3 init -p
 mkdir src
 mkdir src/app
 mkdir src/components


### PR DESCRIPTION
Fixed the Tailwind CSS command in the “Using Client Components” tutorial