### PR TITLE
fix: rolldown-vite version rollback

### DIFF
--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -125,7 +125,7 @@
     "remark-frontmatter": "^5.0.0",
     "remark-mdx-frontmatter": "^4.0.0",
     "rolldown": "1.0.0-beta.8-commit.2686eb1",
-    "rolldown-vite": "^6.3.5",
+    "rolldown-vite": "6.3.5",
     "sass": "^1.86.0",
     "semver": "^7.6.3",
     "source-map": "^0.7.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,7 +149,7 @@ importers:
         version: 4.0.0
       vite-plugin-svgr:
         specifier: ^4.2.0
-        version: 4.2.0(rollup@4.40.1)(typescript@5.7.2)(vite@6.3.4(@types/node@22.9.0)(jiti@2.4.2)(less@4.2.0)(lightningcss@1.29.3)(sass@1.86.0)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.37.0)(yaml@2.5.0))
+        version: 4.2.0(rollup@4.40.1)(typescript@5.7.2)
     devDependencies:
       '@inlang/paraglide-js':
         specifier: 1.11.8
@@ -572,7 +572,7 @@ importers:
         version: 1.43.3(@tanstack/react-router@1.43.3(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731))(csstype@3.1.3)(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
       '@tanstack/router-plugin':
         specifier: ^1.39.13
-        version: 1.43.1(vite@6.3.4(@types/node@22.9.0)(jiti@2.4.2)(less@4.2.0)(lightningcss@1.29.3)(sass@1.86.0)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.37.0)(yaml@2.5.0))
+        version: 1.43.1
       '@types/react':
         specifier: ^18.3.2
         version: 18.3.5
@@ -726,7 +726,7 @@ importers:
         version: 18.3.0
       '@vitejs/plugin-react-oxc':
         specifier: ^0.1.1
-        version: 0.1.1(vite@6.3.4(@types/node@20.17.11)(jiti@2.4.2)(less@4.2.0)(lightningcss@1.29.3)(sass@1.86.0)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.37.0)(yaml@2.5.0))
+        version: 0.1.1
       acorn-loose:
         specifier: ^8.4.0
         version: 8.4.0
@@ -812,7 +812,7 @@ importers:
         specifier: 1.0.0-beta.8-commit.2686eb1
         version: 1.0.0-beta.8-commit.2686eb1(@oxc-project/runtime@0.66.0)(typescript@5.7.2)
       rolldown-vite:
-        specifier: ^6.3.5
+        specifier: 6.3.5
         version: 6.3.5(@types/node@20.17.11)(esbuild@0.25.1)(jiti@2.4.2)(less@4.2.0)(sass@1.86.0)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.37.0)(typescript@5.7.2)(yaml@2.5.0)
       sass:
         specifier: ^1.86.0
@@ -3585,7 +3585,7 @@ packages:
   '@tailwindcss/vite@4.0.9':
     resolution: {integrity: sha512-BIKJO+hwdIsN7V6I7SziMZIVHWWMsV/uCQKYEbeiGRDRld+TkqyRRl9+dQ0MCXbhcVr+D9T/qX2E84kT7V281g==}
     peerDependencies:
-      vite: ^5.2.0 || ^6
+      vite: npm:rolldown-vite@6.3.5
 
   '@tanstack/history@1.41.0':
     resolution: {integrity: sha512-euTyZoHidW1+NeAW9V7SSPNjD6c54TBqKBO8HypA880HWlTXLW6V8rcBnfi1LY1W706dGCvDmZDTg6fsl/jJUw==}
@@ -3629,7 +3629,7 @@ packages:
     engines: {node: '>=12'}
     peerDependencies:
       '@rsbuild/core': '>=0.7.9'
-      vite: '>=5.0.13'
+      vite: npm:rolldown-vite@6.3.5
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
@@ -4207,7 +4207,7 @@ packages:
     resolution: {integrity: sha512-1pGZcXfB5JGPuEwHxwScknfO6Lmz9agEmCuG6diruRhBjMgdro5tjJbz3dKlqxibTtpsiX01aaLHhfpc0l9/yg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      vite: ^6.3.0
+      vite: npm:rolldown-vite@6.3.5
 
   '@vitest/expect@3.0.9':
     resolution: {integrity: sha512-5eCqRItYgIML7NNVgJj6TVCmdzE7ZVgJhruW0ziSQV4V7PvLkDL1bBkBdcTs/VuIz0IxPb5da1IDSqc1TR9eig==}
@@ -4216,7 +4216,7 @@ packages:
     resolution: {integrity: sha512-ryERPIBOnvevAkTq+L1lD+DTFBRcjueL9lOUfXsLfwP92h4e+Heb+PjiqS3/OURWPtywfafK0kj++yDFjWUmrA==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0
+      vite: npm:rolldown-vite@6.3.5
     peerDependenciesMeta:
       msw:
         optional: true
@@ -9235,47 +9235,7 @@ packages:
   vite-plugin-svgr@4.2.0:
     resolution: {integrity: sha512-SC7+FfVtNQk7So0XMjrrtLAbEC8qjFPifyD7+fs/E6aaNdVde6umlVVh0QuwDLdOMu7vp5RiGFsB70nj5yo0XA==}
     peerDependencies:
-      vite: ^2.6.0 || 3 || 4 || 5
-
-  vite@6.3.4:
-    resolution: {integrity: sha512-BiReIiMS2fyFqbqNT/Qqt4CVITDU9M9vE+DKcVAsB+ZV0wvTKd+3hMbkpxz1b+NmEDMegpVbisKiAZOnvO92Sw==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      jiti: '>=1.21.0'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
+      vite: npm:rolldown-vite@6.3.5
 
   vitest@3.0.9:
     resolution: {integrity: sha512-BbcFDqNyBlfSpATmTtXOAOj71RNKDDvjBM/uPfnxxVGrG+FSH2RQIwgeEngTaTkuU/h0ScFvf+tRcKfYXzBybQ==}
@@ -12880,7 +12840,7 @@ snapshots:
       prettier: 3.3.2
       zod: 3.23.8
 
-  '@tanstack/router-plugin@1.43.1(vite@6.3.4(@types/node@22.9.0)(jiti@2.4.2)(less@4.2.0)(lightningcss@1.29.3)(sass@1.86.0)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.37.0)(yaml@2.5.0))':
+  '@tanstack/router-plugin@1.43.1':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/generator': 7.24.7
@@ -12898,8 +12858,6 @@ snapshots:
       babel-dead-code-elimination: 1.0.5
       unplugin: 1.10.2
       zod: 3.23.8
-    optionalDependencies:
-      vite: 6.3.4(@types/node@22.9.0)(jiti@2.4.2)(less@4.2.0)(lightningcss@1.29.3)(sass@1.86.0)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.37.0)(yaml@2.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13532,9 +13490,7 @@ snapshots:
 
   '@vercel/speed-insights@1.1.0': {}
 
-  '@vitejs/plugin-react-oxc@0.1.1(vite@6.3.4(@types/node@20.17.11)(jiti@2.4.2)(less@4.2.0)(lightningcss@1.29.3)(sass@1.86.0)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.37.0)(yaml@2.5.0))':
-    dependencies:
-      vite: 6.3.4(@types/node@20.17.11)(jiti@2.4.2)(less@4.2.0)(lightningcss@1.29.3)(sass@1.86.0)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.37.0)(yaml@2.5.0)
+  '@vitejs/plugin-react-oxc@0.1.1': {}
 
   '@vitest/expect@3.0.9':
     dependencies:
@@ -14899,6 +14855,7 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.1
       '@esbuild/win32-ia32': 0.25.1
       '@esbuild/win32-x64': 0.25.1
+    optional: true
 
   escalade@3.1.2: {}
 
@@ -19541,56 +19498,15 @@ snapshots:
       - typescript
       - yaml
 
-  vite-plugin-svgr@4.2.0(rollup@4.40.1)(typescript@5.7.2)(vite@6.3.4(@types/node@22.9.0)(jiti@2.4.2)(less@4.2.0)(lightningcss@1.29.3)(sass@1.86.0)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.37.0)(yaml@2.5.0)):
+  vite-plugin-svgr@4.2.0(rollup@4.40.1)(typescript@5.7.2):
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.40.1)
       '@svgr/core': 8.1.0(typescript@5.7.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.7.2))
-      vite: 6.3.4(@types/node@22.9.0)(jiti@2.4.2)(less@4.2.0)(lightningcss@1.29.3)(sass@1.86.0)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.37.0)(yaml@2.5.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
-
-  vite@6.3.4(@types/node@20.17.11)(jiti@2.4.2)(less@4.2.0)(lightningcss@1.29.3)(sass@1.86.0)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.37.0)(yaml@2.5.0):
-    dependencies:
-      esbuild: 0.25.1
-      fdir: 6.4.4(picomatch@4.0.2)
-      picomatch: 4.0.2
-      postcss: 8.5.3
-      rollup: 4.40.1
-      tinyglobby: 0.2.13
-    optionalDependencies:
-      '@types/node': 20.17.11
-      fsevents: 2.3.3
-      jiti: 2.4.2
-      less: 4.2.0
-      lightningcss: 1.29.3
-      sass: 1.86.0
-      stylus: 0.62.0
-      sugarss: 4.0.1(postcss@8.5.3)
-      terser: 5.37.0
-      yaml: 2.5.0
-
-  vite@6.3.4(@types/node@22.9.0)(jiti@2.4.2)(less@4.2.0)(lightningcss@1.29.3)(sass@1.86.0)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.37.0)(yaml@2.5.0):
-    dependencies:
-      esbuild: 0.25.1
-      fdir: 6.4.4(picomatch@4.0.2)
-      picomatch: 4.0.2
-      postcss: 8.5.3
-      rollup: 4.40.1
-      tinyglobby: 0.2.13
-    optionalDependencies:
-      '@types/node': 22.9.0
-      fsevents: 2.3.3
-      jiti: 2.4.2
-      less: 4.2.0
-      lightningcss: 1.29.3
-      sass: 1.86.0
-      stylus: 0.62.0
-      sugarss: 4.0.1(postcss@8.5.3)
-      terser: 5.37.0
-      yaml: 2.5.0
 
   vitest@3.0.9(@types/debug@4.1.12)(@types/node@22.9.0)(@vitest/ui@3.0.9)(esbuild@0.25.1)(jiti@2.4.2)(less@4.2.0)(sass@1.86.0)(stylus@0.62.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.37.0)(typescript@5.7.2)(yaml@2.5.0):
     dependencies:


### PR DESCRIPTION
Fix `rolldown-vite` version to 6.3.5 to fix Bun issues