### PR TITLE
fix: css modules scoped name

### DIFF
--- a/packages/react-server/lib/build/client.mjs
+++ b/packages/react-server/lib/build/client.mjs
@@ -227,6 +227,10 @@ export default async function clientBuild(_, options) {
     css: {
       ...config.css,
       postcss: cwd,
+      modules: {
+        generateScopedName: "_[local]_[hash:base64:5]",
+        ...config.css?.modules,
+      },
     },
   };
 

--- a/packages/react-server/lib/build/server.mjs
+++ b/packages/react-server/lib/build/server.mjs
@@ -336,6 +336,10 @@ export default async function serverBuild(root, options) {
     css: {
       ...config.css,
       postcss: cwd,
+      modules: {
+        generateScopedName: "_[local]_[hash:base64:5]",
+        ...config.css?.modules,
+      },
     },
     ssr: {
       ...config.ssr,


### PR DESCRIPTION
Fixes CSS Module scoped names for production builds. This is to prevent client components from having different CSS class names used for SSR/client layers.