### PR TITLE
fix: rolldown advanced chunks

### DIFF
--- a/packages/react-server/lib/build/client.mjs
+++ b/packages/react-server/lib/build/client.mjs
@@ -171,6 +171,10 @@ export default async function clientBuild(_, options) {
           advancedChunks: {
             groups: [
               {
+                name: "react",
+                test: /\/react\/|\/react-dom\/|\/react-server-dom-webpack\//,
+              },
+              {
                 name: "react-server/client/context",
                 test: /react-server\/client\/context/,
               },

--- a/packages/react-server/lib/start/manifest.mjs
+++ b/packages/react-server/lib/start/manifest.mjs
@@ -101,12 +101,17 @@ export async function init$(type = "server", options = {}) {
     );
     const entry =
       type === "client" && browserEntry
-        ? Object.values(manifest.client).find(
-            (entry) =>
-              entry.src &&
-              realpathSync(join(cwd, entry.src)) ===
-                realpathSync(join(cwd, browserEntry?.src))
-          )
+        ? Object.values(manifest.client).find((entry) => {
+            try {
+              return (
+                entry.src &&
+                realpathSync(join(cwd, entry.src)) ===
+                  realpathSync(join(cwd, browserEntry?.src))
+              );
+            } catch {
+              return false;
+            }
+          })
         : Object.values(manifest.server).find(
             (entry) =>
               entry.src &&

--- a/packages/react-server/server/RemoteComponent.jsx
+++ b/packages/react-server/server/RemoteComponent.jsx
@@ -130,7 +130,7 @@ export default async function RemoteComponent({
         const config = forRoot();
         const shared = [
           "rolldown-runtime",
-          "jsx-runtime",
+          "react",
           "react-server/client/context",
           /react-server\/client\/navigation$/,
           /react-server\/client\/location$/,
@@ -162,6 +162,10 @@ export default async function RemoteComponent({
             const remoteEntryUrl = new URL(`/${remote.file}`, remoteUrl).href;
             imports[remoteEntryUrl] = hostEntryUrl;
           }
+        }
+
+        if (Object.keys(imports).length === 0) {
+          return null;
         }
 
         return <script type="importmap">{JSON.stringify({ imports })}</script>;

--- a/packages/react-server/server/render-rsc.jsx
+++ b/packages/react-server/server/render-rsc.jsx
@@ -335,7 +335,8 @@ export async function render(Component, props = {}, options = {}) {
         }
 
         const ModulePreloads =
-          configModulePreload !== false
+          configModulePreload !== false &&
+          !(remote || (origin && host !== origin))
             ? () => {
                 const modules = getContext(CLIENT_MODULES_CONTEXT);
                 return (
@@ -353,18 +354,26 @@ export async function render(Component, props = {}, options = {}) {
             : () => null;
         const ComponentWithStyles = (
           <>
-            <link rel="preconnect" href={origin ?? "/"} id="live-io" />
-            {import.meta.env.DEV && (
+            <link
+              rel="preconnect"
+              href={origin ?? "/"}
+              id={remote ? `live-io-${outlet}` : "live-io"}
+            />
+            {import.meta.env.DEV && !remote && (
               <>
                 <meta name="react-server:cwd" content={cwd()} />
-                <meta
-                  name="react-server:console"
-                  content={String(config.console)}
-                />
-                <meta
-                  name="react-server:overlay"
-                  content={String(config.overlay)}
-                />
+                {typeof config.console !== "undefined" && (
+                  <meta
+                    name="react-server:console"
+                    content={String(config.console)}
+                  />
+                )}
+                {typeof config.overlay !== "undefined" && (
+                  <meta
+                    name="react-server:overlay"
+                    content={String(config.overlay)}
+                  />
+                )}
               </>
             )}
             <Styles />


### PR DESCRIPTION
Fix Rolldown `advancedChunks` to include client components to make `modulepreload` and shared dependency work again.