### PR TITLE
fix: runtime config

### DIFF
--- a/docs/src/pages/en/(pages)/framework/configuration.mdx
+++ b/docs/src/pages/en/(pages)/framework/configuration.mdx
@@ -46,7 +46,7 @@ The following options are specific to the `@lazarv/react-server` framework.
 
 Add new entries to the runtime context. The runtime context is a singleton store and can be used to share state in your application.
 
-```json filename="react-server.config.json"
+```json filename="react-server.runtime.config.json"
 {
   "runtime": {
     "myEntry": "myValue"
@@ -56,7 +56,7 @@ Add new entries to the runtime context. The runtime context is a singleton store
 
 The `runtime` option can also be a function that returns the runtime context object. This is useful when you want to mutate the runtime context.
 
-```mjs filename="react-server.config.mjs"
+```mjs filename="react-server.runtime.config.mjs"
 export default {
   runtime: (runtime) => {
     return {
@@ -65,6 +65,22 @@ export default {
     };
   },
 };
+```
+
+In your application you can retrieve the runtime context using the `getRuntime` function.
+
+```mjs
+import { getRuntime } from "@lazarv/react-server";
+
+const runtime = getRuntime();
+```
+
+You can also directly access the runtime context entries by key using the `getRuntime` function.
+
+```mjs
+import { getRuntime } from "@lazarv/react-server";
+
+const entry = getRuntime("myEntry");
 ```
 
 <Link name="cookies">

--- a/packages/react-server/lib/dev/create-server.mjs
+++ b/packages/react-server/lib/dev/create-server.mjs
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { createRequire, isBuiltin, register } from "node:module";
 import { dirname, join, relative } from "node:path";
@@ -186,7 +187,10 @@ export default async function createServer(root, options) {
       reactServerLive(options.httpServer, config),
     ],
     cacheDir:
-      config.cacheDir || join(cwd, "node_modules", options.outDir, ".cache"),
+      config.cacheDir ||
+      (existsSync(join(cwd, "node_modules"))
+        ? join(cwd, "node_modules", options.outDir, ".cache")
+        : join(cwd, options.outDir, ".cache")),
     resolve: {
       ...config.resolve,
       alias: [
@@ -341,6 +345,7 @@ export default async function createServer(root, options) {
                     "@lazarv/react-server",
                   ],
                   external: [
+                    "picocolors",
                     "unstorage",
                     "@modelcontextprotocol/sdk",
                     "highlight.js",

--- a/packages/react-server/server/index.d.ts
+++ b/packages/react-server/server/index.d.ts
@@ -338,6 +338,21 @@ export function useRender(): {
 };
 
 /**
+ * Get runtime context store.
+ *
+ * @returns The runtime context store.
+ */
+export function getRuntime<R = Record<string, unknown>>(): R;
+
+/**
+ * Get runtime context store entry by key.
+ *
+ * @param key - The key of the store entry to retrieve.
+ * @returns The runtime context store entry.
+ */
+export function getRuntime<R = unknown, K = string>(key?: K): R;
+
+/**
  * The current version of `@lazarv/react-server`.
  */
 export let version: string;

--- a/packages/react-server/server/index.mjs
+++ b/packages/react-server/server/index.mjs
@@ -25,4 +25,5 @@ export { revalidate } from "./revalidate.mjs";
 export { invalidate, useCache } from "../cache/index.mjs";
 export { reload } from "./reload.mjs";
 export { useRender } from "./render.mjs";
+export { getRuntime } from "./runtime.mjs";
 export { version } from "./version.mjs";

--- a/packages/react-server/server/runtime.mjs
+++ b/packages/react-server/server/runtime.mjs
@@ -9,11 +9,6 @@ export function getRuntime(type) {
   return store?.[type];
 }
 
-/**
- * @template T
- * @param {string | Symbol} type
- * @param {T} context
- * */
 export function runtime$(type, context) {
   const store = RuntimeContextStorage.getStore();
   const delta = typeof type === "object" ? type : { [type]: context };


### PR DESCRIPTION
Fixes missing `getRuntime` export from `@lazarv/react-server`.
Fixes `react-server.config.ts` compilation when using relative imports.
When using a `runtime` definition in `react-server.runtme.config.ts`, the `resolve.external` from other configuration files is used to externalize imported modules in `react-server.runtime.config.ts`. This is important when building production and compiling the prebuilt configuration.
Fixes `picocolors` module resolution in development mode.
Fixes development cache location when using `npx`.