### PR TITLE
fix: safari readablestream polyfill

### DIFF
--- a/packages/react-server/client/error-overlay.mjs
+++ b/packages/react-server/client/error-overlay.mjs
@@ -704,16 +704,17 @@ if (
                   ?.getAttribute("content") || null;
               const normalizedArgs = args.map((arg) => {
                 if (arg instanceof Error) {
-                  const stacklines = arg.stack
-                    .split("\n")
-                    .filter((it) => it.trim().startsWith("at "))
-                    .map((it) =>
-                      it
-                        .trim()
-                        .replace(location.origin, it.includes(cwd) ? "" : cwd)
-                        .replace("/@fs", "")
-                        .replace(/\?v=[a-z0-9]+/, "")
-                    );
+                  const stacklines =
+                    arg.stack
+                      ?.split("\n")
+                      .filter((it) => it.trim().startsWith("at "))
+                      .map((it) =>
+                        it
+                          .trim()
+                          .replace(location.origin, it.includes(cwd) ? "" : cwd)
+                          .replace("/@fs", "")
+                          .replace(/\?v=[a-z0-9]+/, "")
+                      ) ?? [];
                   arg.stack = stacklines.join("\n");
                 }
                 return arg;

--- a/packages/react-server/lib/build/client.mjs
+++ b/packages/react-server/lib/build/client.mjs
@@ -152,7 +152,34 @@ export default async function clientBuild(_, options) {
         ...config.build?.rollupOptions,
         preserveEntrySignatures: "strict",
         treeshake: {
-          moduleSideEffects: false,
+          moduleSideEffects: (id, external) => {
+            if (id.includes("/web-streams-polyfill/")) {
+              return true;
+            } else if (
+              typeof config.build?.rollupOptions?.treeshake
+                ?.moduleSideEffects === "function"
+            ) {
+              return config.build.rollupOptions.treeshake.moduleSideEffects(
+                id,
+                external
+              );
+            } else if (
+              Array.isArray(
+                config.build?.rollupOptions?.treeshake?.moduleSideEffects
+              )
+            ) {
+              return config.build.rollupOptions.treeshake.moduleSideEffects.some(
+                (pattern) =>
+                  (typeof pattern === "string" && id.includes(pattern)) ||
+                  (pattern instanceof RegExp && pattern.test(id))
+              );
+            } else if (
+              config.build?.rollupOptions?.treeshake?.moduleSideEffects === true
+            ) {
+              return true;
+            }
+            return false;
+          },
           ...config.build?.rollupOptions?.treeshake,
         },
         external: [

--- a/packages/react-server/lib/build/dependencies.mjs
+++ b/packages/react-server/lib/build/dependencies.mjs
@@ -47,6 +47,9 @@ const unstorageDriversSessionStorage = normalizePath(
   __require.resolve("unstorage/drivers/session-storage")
 );
 const socketIoClient = normalizePath(__require.resolve("socket.io-client"));
+const webStreamsPolyfillPolyfill = normalizePath(
+  __require.resolve("web-streams-polyfill/polyfill")
+);
 
 export {
   react,
@@ -67,4 +70,5 @@ export {
   unstorageDriversLocalStorage,
   unstorageDriversSessionStorage,
   socketIoClient,
+  webStreamsPolyfillPolyfill,
 };

--- a/packages/react-server/lib/build/resolve.mjs
+++ b/packages/react-server/lib/build/resolve.mjs
@@ -72,4 +72,9 @@ export const clientAlias = (dev) => [
     replacement: dependencies.socketIoClient,
     id: "socket.io-client",
   },
+  {
+    find: /^web-streams-polyfill\/polyfill$/,
+    replacement: dependencies.webStreamsPolyfillPolyfill,
+    id: "web-streams-polyfill/polyfill",
+  },
 ];

--- a/packages/react-server/lib/dev/create-server.mjs
+++ b/packages/react-server/lib/dev/create-server.mjs
@@ -160,6 +160,7 @@ export default async function createServer(root, options) {
         "highlight.js/lib/languages/json",
         "highlight.js/lib/languages/xml",
         "socket.io-client",
+        "web-streams-polyfill/polyfill",
         ...(config.optimizeDeps?.include ?? []),
       ],
     },

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -160,6 +160,7 @@
     "strip-ansi": "^7.1.0",
     "style-to-js": "^1.1.12",
     "unstorage": "^1.16.0",
+    "web-streams-polyfill": "^4.2.0",
     "zod": "^3.23.8"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,7 +162,7 @@ importers:
         version: 18.3.5
       autoprefixer:
         specifier: ^10.4.19
-        version: 10.4.19(postcss@8.5.3)
+        version: 10.4.19(postcss@8.5.6)
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
@@ -884,6 +884,9 @@ importers:
       unstorage:
         specifier: ^1.16.0
         version: 1.16.0(idb-keyval@6.2.2)
+      web-streams-polyfill:
+        specifier: ^4.2.0
+        version: 4.2.0
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -9749,6 +9752,10 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  web-streams-polyfill@4.2.0:
+    resolution: {integrity: sha512-0rYDzGOh9EZpig92umN5g5D/9A1Kff7k0/mzPSSCY8jEQeYkgRMoY7LhbXtUCWzLCMX0TUE9aoHkjFNB7D9pfA==}
+    engines: {node: '>= 8'}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -14490,6 +14497,16 @@ snapshots:
       normalize-range: 0.1.2
       picocolors: 1.0.1
       postcss: 8.5.3
+      postcss-value-parser: 4.2.0
+
+  autoprefixer@10.4.19(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.25.1
+      caniuse-lite: 1.0.30001690
+      fraction.js: 4.3.7
+      normalize-range: 0.1.2
+      picocolors: 1.0.1
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -20487,6 +20504,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-streams-polyfill@4.2.0: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
This PR introduces `web-stream-polyfill` because Safari lacks an implementation of `ReadableByteStreamController`, and the client provider was broken without the polyfill in Safari. Fixes #241 