### PR TITLE
fix: externalize commonjs

### DIFF
--- a/examples/react-modal/App.jsx
+++ b/examples/react-modal/App.jsx
@@ -1,0 +1,11 @@
+import ModalParent from "./ModalParent.jsx";
+
+export default function App() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body suppressHydrationWarning>
+        <ModalParent />
+      </body>
+    </html>
+  );
+}

--- a/examples/react-modal/ModalParent.jsx
+++ b/examples/react-modal/ModalParent.jsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState } from "react";
+import Modal from "react-modal";
+
+export default function ModalParent() {
+  const [visible, setVisible] = useState(false);
+  const customStyles = {
+    content: {
+      top: "calc(50% - 100px)",
+      left: "30%",
+      width: "40%",
+      height: "100px",
+      backgroundColor: "lightgray",
+      border: "1px solid black",
+    },
+  };
+  return (
+    <div>
+      <Modal isOpen={visible} style={customStyles} ariaHideApp={false}>
+        <button onClick={() => setVisible(false)}>Hide Modal</button>
+      </Modal>
+      <button onClick={() => setVisible(true)}>Show Modal</button>
+    </div>
+  );
+}

--- a/examples/react-modal/package.json
+++ b/examples/react-modal/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@lazarv/react-server-example-react-modal",
+  "private": true,
+  "description": "@lazarv/react-server React Modal example application",
+  "scripts": {
+    "dev": "react-server ./App.jsx",
+    "build": "react-server build ./App.jsx",
+    "start": "react-server start"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@lazarv/react-server": "workspace:^",
+    "react-modal": "^3.16.3"
+  }
+}

--- a/packages/react-server/lib/plugins/optimize-deps.mjs
+++ b/packages/react-server/lib/plugins/optimize-deps.mjs
@@ -30,9 +30,11 @@ export default function optimizeDeps() {
           (bareImportRE.test(specifier) ||
             (specifier[0] !== "." && specifier[0] !== "/")) &&
           applyAlias(alias, specifier) === specifier &&
-          !isModule(path) &&
           tryStat(path)?.isFile()
         ) {
+          if (!isModule(path)) {
+            return { externalize: specifier };
+          }
           try {
             const content = await readFile(path, "utf-8");
             const ast = this.parse(content);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -554,6 +554,15 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@18.3.5)(react@19.0.0-rc-a7d1240c-20240731)
 
+  examples/react-modal:
+    dependencies:
+      '@lazarv/react-server':
+        specifier: workspace:^
+        version: link:../../packages/react-server
+      react-modal:
+        specifier: ^3.16.3
+        version: 3.16.3(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731)
+
   examples/react-query:
     dependencies:
       '@lazarv/react-server':
@@ -5883,6 +5892,9 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
+  exenv@1.2.2:
+    resolution: {integrity: sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==}
+
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
@@ -8374,11 +8386,20 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-lifecycles-compat@3.0.4:
+    resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
+
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
       '@types/react': '>=18'
       react: '>=18'
+
+  react-modal@3.16.3:
+    resolution: {integrity: sha512-yCYRJB5YkeQDQlTt17WGAgFJ7jr2QYcWa1SHqZ3PluDmnKJ/7+tVU+E6uKyZ0nODaeEj+xCpK4LcSnKXLMC0Nw==}
+    peerDependencies:
+      react: ^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19
+      react-dom: ^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19
 
   react-number-format@5.4.1:
     resolution: {integrity: sha512-NICOjo/70dcAiwVmH6zMWoZrTQDlBrEXV/f7S0t/ewlpzp4z00pasg5G1yBX6NHLafwOF3QZ+VvK/XApwSKxdA==}
@@ -9750,6 +9771,9 @@ packages:
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
+  warning@4.0.3:
+    resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
   watchpack@2.4.2:
     resolution: {integrity: sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==}
@@ -15841,6 +15865,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  exenv@1.2.2: {}
+
   exit@0.1.2: {}
 
   expand-template@2.0.3: {}
@@ -18857,6 +18883,8 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-lifecycles-compat@3.0.4: {}
+
   react-markdown@10.1.0(@types/react@18.3.5)(react@19.0.0-rc-a7d1240c-20240731):
     dependencies:
       '@types/hast': 3.0.4
@@ -18874,6 +18902,15 @@ snapshots:
       vfile: 6.0.1
     transitivePeerDependencies:
       - supports-color
+
+  react-modal@3.16.3(react-dom@19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731))(react@19.0.0-rc-a7d1240c-20240731):
+    dependencies:
+      exenv: 1.2.2
+      prop-types: 15.8.1
+      react: 19.0.0-rc-a7d1240c-20240731
+      react-dom: 19.0.0-rc-3208e73e-20240730(react@19.0.0-rc-a7d1240c-20240731)
+      react-lifecycles-compat: 3.0.4
+      warning: 4.0.3
 
   react-number-format@5.4.1(react-dom@19.0.0-rc-3208e73e-20240730):
     dependencies:
@@ -20491,6 +20528,10 @@ snapshots:
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
+
+  warning@4.0.3:
+    dependencies:
+      loose-envify: 1.4.0
 
   watchpack@2.4.2:
     dependencies:

--- a/test/__test__/apps/react-modal.spec.mjs
+++ b/test/__test__/apps/react-modal.spec.mjs
@@ -1,0 +1,25 @@
+import { join } from "node:path";
+
+import { hostname, page, server, waitForHydration } from "playground/utils";
+import { expect, test } from "vitest";
+
+process.chdir(join(process.cwd(), "../examples/react-modal"));
+
+test("react-modal load", async () => {
+  await server("./App.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+
+  const showModal = page.getByText("Show Modal");
+  await showModal.waitFor({ state: "visible" });
+  expect(await showModal.isVisible()).toBe(true);
+
+  await showModal.click();
+  const hideModal = page.getByText("Hide Modal");
+  await hideModal.waitFor({ state: "visible" });
+  expect(await hideModal.isVisible()).toBe(true);
+
+  await hideModal.click();
+  await showModal.waitFor({ state: "visible" });
+  expect(await showModal.isVisible()).toBe(true);
+});


### PR DESCRIPTION
Fixes externalizing CommonJS modules when the module is not actually an ES module, despite having an ES `"module"` entrypoint in `package.json`.

This is a workaround that incurs a performance hit on module resolution, as the file needs to be parsed and checked for ES module syntax.

Relates to #248 