### PR TITLE
fix: ssr resolve react-server-dom-webpack/client.edge

### DIFF
--- a/packages/react-server/lib/build/resolve.mjs
+++ b/packages/react-server/lib/build/resolve.mjs
@@ -37,6 +37,11 @@ export const clientAlias = (dev) => [
     replacement: dependencies.reactServerDomWebpackServerBrowser,
     id: "react-server-dom-webpack/server.browser",
   },
+  {
+    find: /^react-server-dom-webpack\/client.edge$/,
+    replacement: dependencies.reactServerDomWebpackClientEdge,
+    id: "react-server-dom-webpack/client.edge",
+  },
   { find: /^react-is$/, replacement: dependencies.reactIs, id: "react-is" },
   ...(dependencies.scheduler
     ? [

--- a/packages/react-server/lib/dev/create-logger.mjs
+++ b/packages/react-server/lib/dev/create-logger.mjs
@@ -45,6 +45,11 @@ export default function createLogger(level = "info", options) {
     if (args.length === 0) return args;
 
     const [formatString, ...params] = args;
+
+    if (typeof formatString !== "string") {
+      return args;
+    }
+
     const formatSpecifiers = formatString.match(/%%|%[sdifoOjc]/g) || [];
     const styleIndices = [];
     let paramIndex = 0;


### PR DESCRIPTION
Fixes resolving `react-server-dom-webpack/client.edge` in SSR when using `npm`.
Fixes logger when using a non-string value as the first argument of `console.log`.