### PR TITLE
feat: use vite env loader

### DIFF
--- a/examples/env/.env
+++ b/examples/env/.env
@@ -1,0 +1,7 @@
+VITE_API_URL=https://api.example.com
+VITE_API_KEY=your_api_key_here
+REACT_SERVER_API_URL=https://api.example.com
+REACT_SERVER_API_KEY=your_api_key_here
+MY_SECRET_VALUE=super_secret_value
+APP_ENV=development
+APP_PORT=5173

--- a/examples/env/App.jsx
+++ b/examples/env/App.jsx
@@ -1,0 +1,12 @@
+export default function App() {
+  return (
+    <>
+      <h1>Define</h1>
+      <pre>__APP_ENV__: {__APP_ENV__}</pre>
+      <h1>process.env</h1>
+      <pre>{JSON.stringify(process.env, null, 2)}</pre>
+      <h1>import.meta.env</h1>
+      <pre>{JSON.stringify(import.meta.env, null, 2)}</pre>
+    </>
+  );
+}

--- a/examples/env/package.json
+++ b/examples/env/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@lazarv/react-server-example-env",
+  "private": true,
+  "description": "@lazarv/react-server Environment Variables example application",
+  "scripts": {
+    "dev": "REACT_SERVER_VALUE=1 react-server ./App.jsx",
+    "build": "REACT_SERVER_VALUE=1 react-server build ./App.jsx",
+    "start": "react-server start"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@lazarv/react-server": "workspace:^"
+  }
+}

--- a/examples/env/vite.config.mjs
+++ b/examples/env/vite.config.mjs
@@ -1,0 +1,18 @@
+import { defineConfig, loadEnv } from "vite";
+
+export default defineConfig(({ mode }) => {
+  // Load env file based on `mode` in the current working directory.
+  // Set the third parameter to '' to load all env regardless of the
+  // `VITE_` prefix.
+  const env = loadEnv(mode, process.cwd(), "");
+  return {
+    define: {
+      // Provide an explicit app-level constant derived from an env var.
+      __APP_ENV__: JSON.stringify(env.APP_ENV),
+    },
+    // Example: use an env var to set the dev server port conditionally.
+    server: {
+      port: env.APP_PORT ? Number(env.APP_PORT) : 5173,
+    },
+  };
+});

--- a/packages/react-server/bin/commands/build.mjs
+++ b/packages/react-server/bin/commands/build.mjs
@@ -26,6 +26,7 @@ export default (cli) =>
     .option("--outDir <dir>", "[string] output directory", {
       default: ".react-server",
     })
+    .option("--mode <mode>", "[string] mode", { default: "production" })
     .action(async (root, options) => {
       setEnv("NODE_ENV", "production");
       return (await import("../../lib/build/action.mjs")).default(

--- a/packages/react-server/bin/commands/dev.mjs
+++ b/packages/react-server/bin/commands/dev.mjs
@@ -29,6 +29,7 @@ export default (cli) =>
       default: "react-server",
     })
     .option("--inspect", "enable inspector", { default: false })
+    .option("--mode <mode>", "[string] mode", { default: "development" })
     .action(async (...args) => {
       setEnv("NODE_ENV", "development");
       return (await import("../../lib/dev/action.mjs")).default(...args);

--- a/packages/react-server/lib/build/client.mjs
+++ b/packages/react-server/lib/build/client.mjs
@@ -71,6 +71,22 @@ export default async function clientBuild(_, options) {
   const buildConfig = {
     root: cwd,
     configFile: false,
+    mode: options.mode || "production",
+    define: config.define,
+    envDir: config.envDir,
+    envPrefix:
+      config.envDir !== false
+        ? [
+            "VITE_",
+            "REACT_SERVER_",
+            ...(typeof config.envPrefix !== "undefined"
+              ? Array.isArray(config.envPrefix)
+                ? config.envPrefix
+                : [config.envPrefix]
+              : []),
+          ]
+        : undefined,
+    assetsInclude: config.assetsInclude,
     resolve: {
       ...config.resolve,
       alias: [

--- a/packages/react-server/lib/build/server.mjs
+++ b/packages/react-server/lib/build/server.mjs
@@ -174,6 +174,21 @@ export default async function serverBuild(root, options) {
   const buildConfig = {
     root: cwd,
     configFile: false,
+    mode: options.mode || "production",
+    define: config.define,
+    envDir: config.envDir,
+    envPrefix:
+      config.envDir !== false
+        ? [
+            "VITE_",
+            "REACT_SERVER_",
+            ...(typeof config.envPrefix !== "undefined"
+              ? Array.isArray(config.envPrefix)
+                ? config.envPrefix
+                : [config.envPrefix]
+              : []),
+          ]
+        : undefined,
     resolve: {
       ...config.resolve,
       preserveSymlinks: true,

--- a/packages/react-server/lib/dev/action.mjs
+++ b/packages/react-server/lib/dev/action.mjs
@@ -74,9 +74,11 @@ export default async function dev(root, options) {
                   onWatch(watcher) {
                     configWatcher = watcher;
                   },
-                  async onChange() {
+                  async onChange(e) {
                     getRuntime(LOGGER_CONTEXT)?.warn?.(
-                      `Configuration changed, restarting server...`
+                      e?.startsWith?.(".env")
+                        ? `${colors.green(e)} changed, restarting server...`
+                        : `Configuration changed, restarting server...`
                     );
                     await restartServer();
                   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,12 @@ importers:
         specifier: ^11.5.4
         version: 11.5.4(@emotion/is-prop-valid@1.3.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
+  examples/env:
+    dependencies:
+      '@lazarv/react-server':
+        specifier: workspace:^
+        version: link:../../packages/react-server
+
   examples/express:
     dependencies:
       '@lazarv/react-server':
@@ -9280,6 +9286,7 @@ packages:
   supertest@6.3.4:
     resolution: {integrity: sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==}
     engines: {node: '>=6.4.0'}
+    deprecated: Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}

--- a/test/__test__/apps/env.spec.mjs
+++ b/test/__test__/apps/env.spec.mjs
@@ -1,0 +1,30 @@
+import { join } from "node:path";
+
+import { hostname, page, server } from "playground/utils";
+import { expect, test } from "vitest";
+
+process.chdir(join(process.cwd(), "../examples/env"));
+process.env.REACT_SERVER_VALUE = "1";
+
+test("env load", async () => {
+  await server("./App.jsx");
+  await page.goto(hostname);
+
+  const bodyText = await page.textContent("body");
+  expect(bodyText).toContain("__APP_ENV__: development");
+
+  if (process.env.NODE_ENV === "development") {
+    expect(bodyText).toContain(`"MY_SECRET_VALUE": "super_secret_value"`);
+    expect(bodyText).toContain(`"APP_ENV": "development"`);
+    expect(bodyText).toContain(`"APP_PORT": "${server.port}"`);
+  }
+
+  expect(bodyText).toContain(`"VITE_API_KEY": "your_api_key_here"`);
+  expect(bodyText).toContain(`"VITE_API_URL": "https://api.example.com"`);
+
+  expect(bodyText).toContain(`"REACT_SERVER_API_KEY": "your_api_key_here"`);
+  expect(bodyText).toContain(
+    `"REACT_SERVER_API_URL": "https://api.example.com"`
+  );
+  expect(bodyText).toContain(`"REACT_SERVER_VALUE": "1"`);
+});


### PR DESCRIPTION
This PR enables Vite environment loading when using the development server or in production builds, using the standard solution that Vite provides, as described at https://vite.dev/config/#using-environment-variables-in-config.

A new `--mode` option was introduced for the development server and build CLI commands, which acts the same way as for Vite.

Vite configuration as a function is now supported the same way as in Vite, with the only caveat that `isSsrBuild` and `isPreview` are not implemented, as these are not useful when using the framework.

The development server also uses the configuration watcher to include `.env` files and restarts the server on changes.

Minor fixes were also included regarding the Vite configuration merging.