### PR TITLE
fix: handle redirect when calling server functions from client

### DIFF
--- a/packages/react-server/client/ClientProvider.jsx
+++ b/packages/react-server/client/ClientProvider.jsx
@@ -519,6 +519,15 @@ export const streamOptions = ({
                       emit(outlet, url, {});
                     }
                   } catch (e) {
+                    if (
+                      e?.message === "Redirect" &&
+                      e?.digest.startsWith("Location=")
+                    ) {
+                      navigate(e.digest.slice(9), {
+                        outlet: target,
+                        external: target !== PAGE_ROOT,
+                      });
+                    }
                     reject(e);
                   }
                 }

--- a/test/__test__/server-function-types.spec.mjs
+++ b/test/__test__/server-function-types.spec.mjs
@@ -47,6 +47,14 @@ const validator = {
       "timestamp"
     );
   },
+  "redirect-action": async (page) => {
+    await page.waitForFunction(
+      () => window.location.pathname === "/some-other-page"
+    );
+    expect(await page.evaluate(() => window.location.pathname)).toBe(
+      "/some-other-page"
+    );
+  },
   "stream-action": async (page) => {
     await page.waitForFunction(
       () => window.__react_server_result__ !== undefined

--- a/test/fixtures/actions.mjs
+++ b/test/fixtures/actions.mjs
@@ -1,6 +1,6 @@
 "use server";
 
-import { reload, status } from "@lazarv/react-server";
+import { redirect, reload, status } from "@lazarv/react-server";
 
 export async function serverAction() {
   console.log("submitted server-action!");
@@ -98,4 +98,9 @@ export async function reloadAction() {
   console.log("submitted reload-action!");
   reload("/", "rsf");
   return { hello: "world", timestamp: Date.now() };
+}
+
+export async function redirectAction() {
+  console.log("submitted redirect-action!");
+  redirect("/some-other-page");
 }

--- a/test/fixtures/server-function-types-actions.jsx
+++ b/test/fixtures/server-function-types-actions.jsx
@@ -11,6 +11,7 @@ import {
   noContentAction,
   errorAction,
   reloadAction,
+  redirectAction,
   streamAction,
   iteratorAction,
 } from "./actions.mjs";
@@ -122,6 +123,13 @@ export default function ServerFunctionTypes() {
         }
       >
         reload-action
+      </button>
+      <button
+        onClick={async () =>
+          console.log((window.__react_server_result__ = await redirectAction()))
+        }
+      >
+        redirect-action
       </button>
     </>
   );

--- a/test/fixtures/server-function-types.jsx
+++ b/test/fixtures/server-function-types.jsx
@@ -1,12 +1,13 @@
 import { ReactServerComponent } from "@lazarv/react-server/navigation";
 import ServerFunctionTypesActions from "./server-function-types-actions.jsx";
-import { outlet } from "@lazarv/react-server";
+import { outlet, usePathname } from "@lazarv/react-server";
 import { useActionState } from "@lazarv/react-server/router";
 import { reloadAction } from "./actions.mjs";
 
 export default function ServerFunctionTypes() {
   const currentOutlet = outlet();
   const { data, error } = useActionState(reloadAction);
+  const pathname = usePathname();
 
   if (error) {
     return <pre>{error.stack}</pre>;
@@ -18,6 +19,7 @@ export default function ServerFunctionTypes() {
 
   return (
     <>
+      <pre>Pathname: {pathname}</pre>
       <ServerFunctionTypesActions />
       <ReactServerComponent outlet="rsf" />
     </>


### PR DESCRIPTION
This PR fixes handling redirects when calling server functions from client components directly.
Server function type test cases were extended to include a redirect use case.