### PR TITLE
feat: router matchers

### DIFF
--- a/docs/src/pages/en/(pages)/router/define-routes.mdx
+++ b/docs/src/pages/en/(pages)/router/define-routes.mdx
@@ -75,6 +75,8 @@ export default function User({ id, name }) {
 }
 ```
 
+> **Matcher alias:** a parameter bracket can carry an `=alias` suffix — e.g. `[id=numeric].page.jsx` → `/[id=numeric]`. The alias binds the segment to a predicate supplied via `export const matchers`, letting you gate the route on the segment's shape before it matches. See [Route matchers](/router/define-routes#route-matchers) below. Plain `[id]` extracts the param without filtering.
+
 <Link name="route-parameters-for-multiple-segments">
 ### Route parameters for multiple segments
 </Link>
@@ -203,6 +205,76 @@ export default products.createPage(() => {
 
 When validation fails (e.g. `/user/abc` with the numeric validation above), `useParams()` returns `null` and `useSearchParams()` returns an empty object `{}`, letting you handle the error in your component or fall through to a fallback route.
 
+<Link name="route-matchers">
+## Route matchers
+</Link>
+
+Matchers are predicates that gate **whether** a route matches a URL in the first place. They run during routing, before any page code loads, and they let sibling routes divide the same parameter space by shape.
+
+Use the matcher syntax by adding an `=alias` suffix inside a parameter bracket in the file name. The alias is the key you'll use in `export const matchers`:
+
+| Bracket form | Example | Matcher receives |
+|--------------|---------|------------------|
+| `[name=alias]` | `[id=numeric].page.tsx` | `string` |
+| `[[name=alias]]` | `[[tab=known]].page.tsx` | `string` |
+| `[...name=alias]` | `[...slug=nested].page.tsx` | `string[]` |
+| `[[...name=alias]]` | `[[...path=valid]].page.tsx` | `string[]` |
+
+Export a `matchers` object from the page (or middleware or API route) whose keys are the aliases used in the path. Each value is a predicate that returns `true` to accept the URL and `false` to reject it. Rejected URLs fall through to sibling routes — they're not 404s by themselves.
+
+```tsx filename="pages/product/[sku=uppercase].page.tsx"
+import { productSkuUppercase } from "@lazarv/react-server/routes";
+
+export const matchers = productSkuUppercase.createMatchers({
+  uppercase: (value) => /^[A-Z0-9-]+$/.test(value),
+});
+
+export default productSkuUppercase.createPage(({ sku }) => {
+  return <h1>Product {sku}</h1>;
+});
+```
+
+Place a sibling `[sku].page.tsx` next to it to catch rejected values:
+
+```tsx filename="pages/product/[sku].page.tsx"
+import { product } from "@lazarv/react-server/routes";
+
+export default product.createPage(({ sku }) => {
+  return <h1>Fallback: {sku}</h1>;
+});
+```
+
+The generated route names (`productSkuUppercase` and `product`) come directly from the derivation rule described in [Route naming](/router/define-routes#routes-module-naming): a matcher-gated segment contributes both its param name and its alias, while a bare dynamic segment is stripped. No explicit `route` override needed.
+
+Now `/product/ABC-123` renders the matcher-gated page, and `/product/abc-123` falls through to the sibling. The runtime tries matcher-gated routes first — more specific routes always rank above less specific siblings at the same path shape.
+
+**Catch-all matchers receive arrays.** The alias suffix works identically on `[...slug]` and `[[...slug]]`, but the predicate gets the whole segment array, not a string:
+
+```tsx filename="pages/docs/[...slug=nested].page.tsx"
+import { docsSlugNested } from "@lazarv/react-server/routes";
+
+export const matchers = docsSlugNested.createMatchers({
+  nested: (slug) => slug.length >= 2,
+});
+
+export default docsSlugNested.createPage(({ slug }) => {
+  return <article>{slug.join("/")}</article>;
+});
+```
+
+Here `/docs/intro` falls through (length 1) but `/docs/guide/install` matches.
+
+**Typed aliases.** The aliases you can pass to `createMatchers` are extracted from the route path at type-generation time. A path like `[id=numeric]` produces `{ numeric?: (value: string) => boolean }`; a path like `[...slug=nested]` produces `{ nested?: (value: string[]) => boolean }`. Using an alias that isn't in the path is a type error.
+
+**Matchers vs validation.** They solve different problems:
+
+- **Matchers** gate **routing**. A rejection means "this URL is not for this route" — sibling routes and fallbacks get a chance. No page code loads.
+- **Validation** gates **the matched route's params**. A rejection means "this route matched, but the params don't satisfy the schema" — `useParams()` returns `null`, the page still renders and must handle the error.
+
+Use matchers when several sibling routes share the same parameter slot but differ in its shape. Use validation when a single route needs to constrain the already-extracted params before rendering.
+
+**Scope.** Matchers are honored on pages, outlet pages, middlewares, and API route handlers. Layouts and error/loading/fallback boundaries don't participate in matcher dispatch — they're selected by containment and by the page they wrap.
+
 <Link name="routes-module">
 ## Routes module
 </Link>
@@ -229,6 +301,7 @@ Plus context-aware helper functions for typing your page components:
 - **`.createError(component)`** — typed error boundary component
 - **`.createFallback(component)`** — typed fallback component
 - **`.createMiddleware(handler)`** — typed middleware with request params
+- **`.createMatchers(matchers)`** — typed matcher map (only on routes whose path contains an `=alias` bracket). Aliases are extracted from the path; catch-all aliases receive `string[]`, single aliases receive `string`. See [Route matchers](/router/define-routes#route-matchers).
 
 These helpers are identity functions at runtime — they return the component unchanged. They exist purely for TypeScript to infer the correct prop types from your route path, `validate` export, and outlet structure.
 
@@ -245,8 +318,10 @@ Route names are derived automatically from the file path using camelCase:
 | `pages/user/[id].page.tsx` | `user` |
 | `pages/user/posts.page.tsx` | `userPosts` |
 | `pages/dashboard/settings.page.tsx` | `dashboardSettings` |
+| `pages/product/[sku=uppercase].page.tsx` | `productSkuUppercase` |
+| `pages/docs/[...slug=nested].page.tsx` | `docsSlugNested` |
 
-Dynamic segments like `[id]` are stripped from the name. Purely dynamic paths like `pages/[id].page.tsx` use the parameter name (`id`) as the route name.
+Dynamic segments like `[id]` are stripped from the name. Purely dynamic paths like `pages/[id].page.tsx` use the parameter name (`id`) as the route name. When a segment carries a matcher alias (e.g. `[sku=uppercase]`), both the param name and the alias contribute to the derived name — so a matcher-gated page and its bare sibling get distinct names automatically, without numeric suffixes. Numeric suffixes are still applied as a last-resort fallback only when the derivation produces a true collision.
 
 You can override the auto-derived name by exporting a `route` constant from your page file:
 

--- a/docs/src/pages/ja/(pages)/router/define-routes.mdx
+++ b/docs/src/pages/ja/(pages)/router/define-routes.mdx
@@ -75,6 +75,8 @@ export default function User({ id, name }) {
 }
 ```
 
+> **マッチャーエイリアス:** パラメータブラケットには`=alias`サフィックスを付けることができます。たとえば`[id=numeric].page.jsx` → `/[id=numeric]`。エイリアスは`export const matchers`で指定した述語にセグメントを結び付け、ルートがマッチする前にセグメントの形状でゲートをかけることができます。後述の[ルートマッチャー](/router/define-routes#route-matchers)を参照してください。プレーンな`[id]`はフィルタリングなしでパラメータを抽出します。
+
 <Link name="route-parameters-for-multiple-segments">
 ### 複数セグメントのルートパラメータ
 </Link>
@@ -203,6 +205,76 @@ export default products.createPage(() => {
 
 バリデーションが失敗した場合（例：上記の数値バリデーションで`/user/abc`）、`useParams()`は`null`を返し、`useSearchParams()`は空のオブジェクト`{}`を返します。これにより、コンポーネントでエラーを処理したり、フォールバックルートに遷移させたりできます。
 
+<Link name="route-matchers">
+## ルートマッチャー
+</Link>
+
+マッチャーは、**URL がそもそもルートにマッチするかどうか**をゲートする述語です。ルーティング時にページコードが読み込まれる前に実行され、同じパラメータ空間を形状によって分割する兄弟ルートを定義できます。
+
+マッチャー構文を使用するには、ファイル名のパラメータブラケット内に`=alias`サフィックスを追加します。エイリアスは`export const matchers`で使用するキーになります。
+
+| ブラケット形式 | 例 | マッチャーが受け取る値 |
+|---------------|-----|----------------------|
+| `[name=alias]` | `[id=numeric].page.tsx` | `string` |
+| `[[name=alias]]` | `[[tab=known]].page.tsx` | `string` |
+| `[...name=alias]` | `[...slug=nested].page.tsx` | `string[]` |
+| `[[...name=alias]]` | `[[...path=valid]].page.tsx` | `string[]` |
+
+ページ（またはミドルウェアや API ルート）から`matchers`オブジェクトをエクスポートします。キーはパスで使用しているエイリアスと一致させます。各値は URL を受け入れる場合は`true`、拒否する場合は`false`を返す述語です。拒否された URL は兄弟ルートにフォールスルーします — それ自体では 404 にはなりません。
+
+```tsx filename="pages/product/[sku=uppercase].page.tsx"
+import { productSkuUppercase } from "@lazarv/react-server/routes";
+
+export const matchers = productSkuUppercase.createMatchers({
+  uppercase: (value) => /^[A-Z0-9-]+$/.test(value),
+});
+
+export default productSkuUppercase.createPage(({ sku }) => {
+  return <h1>Product {sku}</h1>;
+});
+```
+
+その隣に兄弟の`[sku].page.tsx`を配置すると、拒否された値を受け止めます。
+
+```tsx filename="pages/product/[sku].page.tsx"
+import { product } from "@lazarv/react-server/routes";
+
+export default product.createPage(({ sku }) => {
+  return <h1>Fallback: {sku}</h1>;
+});
+```
+
+生成されるルート名（`productSkuUppercase`と`product`）は、[ルート命名](/router/define-routes#routes-module-naming)で説明されている導出ルールから直接得られます。マッチャーでゲートされたセグメントはパラメータ名とエイリアスの両方を寄与させ、ベアなダイナミックセグメントは取り除かれます。明示的な`route`オーバーライドは不要です。
+
+これで`/product/ABC-123`はマッチャーでゲートされたページをレンダリングし、`/product/abc-123`は兄弟にフォールスルーします。ランタイムはマッチャーでゲートされたルートを最初に試します — 同じパス形状でより具体的なルートは、常により具体的でない兄弟よりも上位にランクされます。
+
+**キャッチオールマッチャーは配列を受け取ります。** エイリアスサフィックスは`[...slug]`や`[[...slug]]`でも同様に動作しますが、述語はセグメントの配列全体を受け取り、文字列は受け取りません。
+
+```tsx filename="pages/docs/[...slug=nested].page.tsx"
+import { docsSlugNested } from "@lazarv/react-server/routes";
+
+export const matchers = docsSlugNested.createMatchers({
+  nested: (slug) => slug.length >= 2,
+});
+
+export default docsSlugNested.createPage(({ slug }) => {
+  return <article>{slug.join("/")}</article>;
+});
+```
+
+ここで`/docs/intro`はフォールスルーし（長さ 1）、`/docs/guide/install`はマッチします。
+
+**型付きエイリアス。** `createMatchers`に渡せるエイリアスは、型生成時にルートパスから抽出されます。`[id=numeric]`のようなパスは`{ numeric?: (value: string) => boolean }`を生成し、`[...slug=nested]`のようなパスは`{ nested?: (value: string[]) => boolean }`を生成します。パスに存在しないエイリアスを使用するのは型エラーです。
+
+**マッチャーとバリデーションの違い。** これらは異なる問題を解決します。
+
+- **マッチャー**は**ルーティング**をゲートします。拒否は「この URL はこのルート用ではない」という意味です — 兄弟ルートとフォールバックにチャンスが与えられます。ページコードは読み込まれません。
+- **バリデーション**は**マッチしたルートのパラメータ**をゲートします。拒否は「このルートはマッチしたが、パラメータがスキーマを満たさない」という意味です — `useParams()`は`null`を返し、ページは依然としてレンダリングされ、エラーを処理する必要があります。
+
+複数の兄弟ルートが同じパラメータスロットを共有しつつ、その形状が異なる場合はマッチャーを使用してください。単一のルートがレンダリング前に抽出済みのパラメータを制約する必要がある場合はバリデーションを使用してください。
+
+**スコープ。** マッチャーはページ、アウトレットページ、ミドルウェア、および API ルートハンドラーで尊重されます。レイアウトとエラー/ローディング/フォールバックの境界はマッチャーディスパッチに参加しません — それらは包含関係とラップするページによって選択されます。
+
 <Link name="routes-module">
 ## ルートモジュール
 </Link>
@@ -229,6 +301,7 @@ import { index, about, user, dashboard } from "@lazarv/react-server/routes";
 - **`.createError(component)`** — 型付きエラーバウンダリコンポーネント
 - **`.createFallback(component)`** — 型付きフォールバックコンポーネント
 - **`.createMiddleware(handler)`** — リクエストパラメータ付きの型付きミドルウェア
+- **`.createMatchers(matchers)`** — 型付きマッチャーマップ（パスに`=alias`ブラケットを含むルートでのみ利用可能）。エイリアスはパスから抽出されます。キャッチオールエイリアスは`string[]`を、シングルエイリアスは`string`を受け取ります。[ルートマッチャー](/router/define-routes#route-matchers)を参照してください。
 
 これらのヘルパーはランタイムではアイデンティティ関数です — コンポーネントをそのまま返します。ルートパス、`validate`エクスポート、アウトレット構造から正しいプロップ型を推論するためにTypeScript専用で存在します。
 
@@ -245,8 +318,10 @@ import { index, about, user, dashboard } from "@lazarv/react-server/routes";
 | `pages/user/[id].page.tsx` | `user` |
 | `pages/user/posts.page.tsx` | `userPosts` |
 | `pages/dashboard/settings.page.tsx` | `dashboardSettings` |
+| `pages/product/[sku=uppercase].page.tsx` | `productSkuUppercase` |
+| `pages/docs/[...slug=nested].page.tsx` | `docsSlugNested` |
 
-`[id]`のような動的セグメントは名前から除去されます。`pages/[id].page.tsx`のような純粋に動的なパスでは、パラメータ名（`id`）がルート名として使用されます。
+`[id]`のような動的セグメントは名前から除去されます。`pages/[id].page.tsx`のような純粋に動的なパスでは、パラメータ名（`id`）がルート名として使用されます。セグメントがマッチャーエイリアス（例：`[sku=uppercase]`）を持つ場合、パラメータ名とエイリアスの両方が導出名に寄与します — そのため、マッチャーでゲートされたページとそのベアな兄弟は、数値サフィックスなしで自動的に別々の名前を取得します。数値サフィックスは、導出が真の衝突を生み出した場合の最後の手段としてのみ適用されます。
 
 ページファイルから`route`定数をエクスポートすることで、自動導出された名前をオーバーライドできます：
 

--- a/examples/typed-file-router/pages/(root).layout.tsx
+++ b/examples/typed-file-router/pages/(root).layout.tsx
@@ -6,6 +6,10 @@ import {
   counter,
   clock,
   todos,
+  product,
+  productSkuUppercase,
+  docs,
+  docsSlugNested,
 } from "@lazarv/react-server/routes";
 
 export default index.createLayout(({ children }) => {
@@ -31,6 +35,18 @@ export default index.createLayout(({ children }) => {
           <counter.Link>Counter</counter.Link>
           <clock.Link>Clock</clock.Link>
           <todos.Link>Todos</todos.Link>
+          <productSkuUppercase.Link params={{ sku: "ABC-123" }}>
+            Product ABC-123 (matcher)
+          </productSkuUppercase.Link>
+          <product.Link params={{ sku: "abc-123" }}>
+            Product abc-123 (fallback)
+          </product.Link>
+          <docsSlugNested.Link
+            params={{ slug: ["getting-started", "install"] }}
+          >
+            Docs nested
+          </docsSlugNested.Link>
+          <docs.Link params={{ slug: ["intro"] }}>Docs flat</docs.Link>
         </nav>
         {children}
       </body>

--- a/examples/typed-file-router/pages/docs/[...slug=nested].page.tsx
+++ b/examples/typed-file-router/pages/docs/[...slug=nested].page.tsx
@@ -1,0 +1,23 @@
+import { docs, docsSlugNested } from "@lazarv/react-server/routes";
+
+// Catch-all matcher: receives the slug *array*, not a single string.
+// Only matches when the path has at least two nested segments.
+export const matchers = docsSlugNested.createMatchers({
+  nested: (slug) => slug.length >= 2,
+});
+
+export default docsSlugNested.createPage(({ slug }) => {
+  return (
+    <div>
+      <h1>Docs (nested)</h1>
+      <p data-testid="route">matched=[...slug=nested]</p>
+      <p data-testid="slug">{slug.join("/")}</p>
+      <p>
+        Gated by <code>matchers.nested = (slug) =&gt; slug.length &gt;= 2</code>{" "}
+        — the matcher receives the slug <em>array</em>, not a string. Try a
+        single segment to fall through:{" "}
+        <docs.Link params={{ slug: ["intro"] }}>/docs/intro</docs.Link>.
+      </p>
+    </div>
+  );
+});

--- a/examples/typed-file-router/pages/docs/[...slug].page.tsx
+++ b/examples/typed-file-router/pages/docs/[...slug].page.tsx
@@ -1,0 +1,21 @@
+import { docs, docsSlugNested } from "@lazarv/react-server/routes";
+
+// Fallback — catches single-segment /docs/* where the nested matcher rejects.
+export default docs.createPage(({ slug }) => {
+  return (
+    <div>
+      <h1>Docs (flat)</h1>
+      <p data-testid="route">matched=[...slug]</p>
+      <p data-testid="slug">{slug.join("/")}</p>
+      <p>
+        The sibling <code>[...slug=nested]</code> was tried first and its
+        matcher rejected this path (fewer than 2 segments). Try a deeper URL to
+        hit the matcher:{" "}
+        <docsSlugNested.Link params={{ slug: ["getting-started", "install"] }}>
+          /docs/getting-started/install
+        </docsSlugNested.Link>
+        .
+      </p>
+    </div>
+  );
+});

--- a/examples/typed-file-router/pages/product/[sku=uppercase].page.tsx
+++ b/examples/typed-file-router/pages/product/[sku=uppercase].page.tsx
@@ -1,0 +1,26 @@
+import { product, productSkuUppercase } from "@lazarv/react-server/routes";
+
+export const matchers = productSkuUppercase.createMatchers({
+  uppercase: (value) => /^[A-Z0-9-]+$/.test(value),
+});
+
+export default productSkuUppercase.createPage(({ sku }) => {
+  return (
+    <div>
+      <h1>Product (uppercase SKU)</h1>
+      <p>
+        SKU: <strong data-testid="sku-upper">{sku}</strong>
+      </p>
+      <p data-testid="route">matched=[sku=uppercase]</p>
+      <p>
+        This page is gated by{" "}
+        <code>matchers.uppercase = (v) =&gt; /^[A-Z0-9-]+$/.test(v)</code>. Try
+        a lowercase SKU to fall through to the sibling route:{" "}
+        <product.Link params={{ sku: "abc-123" }}>
+          /product/abc-123
+        </product.Link>
+        .
+      </p>
+    </div>
+  );
+});

--- a/examples/typed-file-router/pages/product/[sku].page.tsx
+++ b/examples/typed-file-router/pages/product/[sku].page.tsx
@@ -1,0 +1,22 @@
+import { product, productSkuUppercase } from "@lazarv/react-server/routes";
+
+export default product.createPage(({ sku }) => {
+  return (
+    <div>
+      <h1>Product (any SKU)</h1>
+      <p>
+        SKU: <strong data-testid="sku-any">{sku}</strong>
+      </p>
+      <p data-testid="route">matched=[sku]</p>
+      <p>
+        This is the fallback. The sibling <code>[sku=uppercase]</code> is tried
+        first and its matcher rejected this value. Try an uppercase SKU to hit
+        the matcher:{" "}
+        <productSkuUppercase.Link params={{ sku: "ABC-123" }}>
+          /product/ABC-123
+        </productSkuUppercase.Link>
+        .
+      </p>
+    </div>
+  );
+});

--- a/packages/react-server/lib/build-href.mjs
+++ b/packages/react-server/lib/build-href.mjs
@@ -1,20 +1,68 @@
 /**
  * Build a URL pathname from a route path pattern and params.
  *
- * @param {string} path - Route path pattern, e.g. "/user/[id]" or "/files/[...path]"
- * @param {Record<string, string | string[]>} params - Param values
- * @returns {string} The resolved pathname
+ * Handles every route-path bracket form, with or without a matcher alias
+ * suffix (e.g. `[id=numeric]`, `[...slug=nested]`). The alias is dropped when
+ * emitting the href — it's a routing-time concern only.
+ *
+ * Bracket forms supported:
+ *   [name]            required param             → string
+ *   [[name]]          optional param             → string | undefined
+ *   [...name]         required catch-all         → string[]
+ *   [[...name]]       optional catch-all         → string[] | undefined
+ * Each form also accepts an `=alias` suffix before the closing bracket(s).
+ *
+ * @param {string} path - Route path pattern.
+ * @param {Record<string, string | string[] | undefined>} params - Param values.
+ * @returns {string} The resolved pathname.
  *
  * @example
- * buildHref("/user/[id]", { id: "42" })       // → "/user/42"
- * buildHref("/files/[...path]", { path: ["a","b"] }) // → "/files/a/b"
- * buildHref("/", {})                            // → "/"
+ * buildHref("/user/[id]", { id: "42" })                    // → "/user/42"
+ * buildHref("/user/[id=numeric]", { id: "42" })            // → "/user/42"
+ * buildHref("/files/[...path]", { path: ["a","b"] })       // → "/files/a/b"
+ * buildHref("/docs/[...slug=nested]", { slug: ["a","b"] }) // → "/docs/a/b"
+ * buildHref("/opt/[[tag]]", {})                            // → "/opt/"
  */
 export function buildHref(path, params = {}) {
   if (!path) return "/";
-  return path.replace(/\[(?:\.\.\.)?(\w+)\]/g, (match, name) => {
-    const value = params[name];
-    if (Array.isArray(value)) return value.map(encodeURIComponent).join("/");
-    return value != null ? encodeURIComponent(String(value)) : match;
-  });
+  // Ordered from longest to shortest so the alternation never under-matches
+  // (e.g. `[[...slug]]` would otherwise match as `[...slug]` surrounded by
+  // stray brackets).
+  //   group 1: [[...name]]          — optional catch-all
+  //   group 2: [...name]            — required catch-all
+  //   group 3: [[name]]             — optional single
+  //   group 4: [name]               — required single
+  const re =
+    /\[\[\.\.\.(\w+)(?:=[^\]]+)?\]\]|\[\.\.\.(\w+)(?:=[^\]]+)?\]|\[\[(\w+)(?:=[^\]]+)?\]\]|\[(\w+)(?:=[^\]]+)?\]/g;
+  const result = path.replace(
+    re,
+    (match, optCatch, reqCatch, optName, reqName) => {
+      if (optCatch !== undefined) {
+        const value = params[optCatch];
+        if (Array.isArray(value))
+          return value.map(encodeURIComponent).join("/");
+        return value == null ? "" : encodeURIComponent(String(value));
+      }
+      if (reqCatch !== undefined) {
+        const value = params[reqCatch];
+        if (Array.isArray(value))
+          return value.map(encodeURIComponent).join("/");
+        // Missing required catch-all: leave literal so the caller sees the gap.
+        return value == null ? match : encodeURIComponent(String(value));
+      }
+      if (optName !== undefined) {
+        const value = params[optName];
+        if (value == null) return "";
+        return encodeURIComponent(String(value));
+      }
+      // reqName
+      const value = params[reqName];
+      if (value == null) return match;
+      if (Array.isArray(value)) return value.map(encodeURIComponent).join("/");
+      return encodeURIComponent(String(value));
+    }
+  );
+  // Collapse any `//` introduced by empty optional substitutions, but preserve
+  // the leading slash.
+  return result.replace(/\/{2,}/g, "/");
 }

--- a/packages/react-server/lib/plugins/file-router/entrypoint.jsx
+++ b/packages/react-server/lib/plugins/file-router/entrypoint.jsx
@@ -38,10 +38,13 @@ export async function init$() {
     async (context) => {
       context$(POSTPONE_CONTEXT, false);
       context$(PAGE_PATH, usePathname());
-      // Resolve all routing-level matchers once per process. After this awaits,
-      // every downstream useMatch(path, …) call can read matchersFor(path)
-      // synchronously. Paths without matchers remain zero-cost.
-      await loadMatchers$();
+      // Resolve all routing-level matchers once per process. loadMatchers$()
+      // returns null synchronously when there are no matchers to load (either
+      // because the app declared none, or because a previous request already
+      // resolved them) — awaiting a resolved promise still queues a microtask
+      // per request, so the synchronous skip matters under benchmark load.
+      const matchersReady = loadMatchers$();
+      if (matchersReady) await matchersReady;
       const initMiddlewares = await Promise.all(
         middlewares.reduce((acc, [path, init$]) => {
           const params = useMatch(path, { matchers: matchersFor(path) });

--- a/packages/react-server/lib/plugins/file-router/entrypoint.jsx
+++ b/packages/react-server/lib/plugins/file-router/entrypoint.jsx
@@ -10,6 +10,8 @@ import {
   useResponseCache,
 } from "@lazarv/react-server";
 import {
+  loadMatchers$,
+  matchersFor,
   middlewares,
   pages,
   routes,
@@ -36,9 +38,13 @@ export async function init$() {
     async (context) => {
       context$(POSTPONE_CONTEXT, false);
       context$(PAGE_PATH, usePathname());
+      // Resolve all routing-level matchers once per process. After this awaits,
+      // every downstream useMatch(path, …) call can read matchersFor(path)
+      // synchronously. Paths without matchers remain zero-cost.
+      await loadMatchers$();
       const initMiddlewares = await Promise.all(
         middlewares.reduce((acc, [path, init$]) => {
-          const params = useMatch(path);
+          const params = useMatch(path, { matchers: matchersFor(path) });
           if (params) {
             acc.push([params, init$]);
           }
@@ -76,7 +82,7 @@ export async function init$() {
       for (const [method, path, _route] of routes) {
         match =
           method === "*" || method === context.request.method
-            ? useMatch(path, { exact: true })
+            ? useMatch(path, { exact: true, matchers: matchersFor(path) })
             : null;
         if (match) {
           route = _route;
@@ -129,7 +135,10 @@ export async function init$() {
           ([, type, outlet]) => type === "page" && outlet === reactServerOutlet
         );
         for (const [path, , , , , lazy] of outlets) {
-          const match = useMatch(path, { exact: true });
+          const match = useMatch(path, {
+            exact: true,
+            matchers: matchersFor(path),
+          });
           if (match) {
             let errorBoundary =
               pages.find(
@@ -228,7 +237,12 @@ export async function init$() {
       const selector = async () => {
         for (const [path, type, outlet, lazy, src] of pages) {
           match =
-            type === "page" && !outlet ? useMatch(path, { exact: true }) : null;
+            type === "page" && !outlet
+              ? useMatch(path, {
+                  exact: true,
+                  matchers: matchersFor(path),
+                })
+              : null;
           if (match) {
             const { default: Component, init$: page_init$ } = await lazy();
             await page_init$?.();
@@ -238,7 +252,12 @@ export async function init$() {
           }
 
           match =
-            type === "page" && outlet ? useMatch(path, { exact: true }) : null;
+            type === "page" && outlet
+              ? useMatch(path, {
+                  exact: true,
+                  matchers: matchersFor(path),
+                })
+              : null;
           if (match) {
             const [, , , lazy] =
               pages.find(

--- a/packages/react-server/lib/plugins/file-router/plugin.mjs
+++ b/packages/react-server/lib/plugins/file-router/plugin.mjs
@@ -2189,6 +2189,9 @@ ${lazyMatchersLines.join("\n")}
             ${pageEntries}
           ];
 
+          ${
+            matcherLoaderEntries
+              ? `
           // Matcher loaders: [path, () => Promise<matchers>] for every
           // routing participant that exports a \`matchers\` object. Paths not
           // present here have no matchers; \`matchersFor(path)\` returns
@@ -2197,8 +2200,14 @@ ${lazyMatchersLines.join("\n")}
             ${matcherLoaderEntries}
           ];
           const __resolvedMatchers = new Map();
+          let __matchersLoaded = false;
           let __matchersLoadPromise = null;
+          // Returns a pending promise while loading, null once settled — so
+          // callers can skip the await entirely on the hot path. Awaiting an
+          // already-resolved promise still queues a microtask, which is
+          // measurable under benchmark load.
           function loadMatchers$() {
+            if (__matchersLoaded) return null;
             if (__matchersLoadPromise) return __matchersLoadPromise;
             __matchersLoadPromise = Promise.all(
               __matcherLoaders.map(async ([path, loader]) => {
@@ -2207,11 +2216,21 @@ ${lazyMatchersLines.join("\n")}
                   __resolvedMatchers.set(path, m);
                 }
               })
-            );
+            ).then(() => {
+              __matchersLoaded = true;
+              __matchersLoadPromise = null;
+            });
             return __matchersLoadPromise;
           }
           function matchersFor(path) {
             return __resolvedMatchers.get(path);
+          }`
+              : `
+          // No routing participant exports a \`matchers\` object in this app —
+          // emit no-op helpers so the routing hot path stays matcher-free
+          // with zero per-request cost.
+          function loadMatchers$() { return null; }
+          function matchersFor() { return undefined; }`
           }
 
           function warmup$() {

--- a/packages/react-server/lib/plugins/file-router/plugin.mjs
+++ b/packages/react-server/lib/plugins/file-router/plugin.mjs
@@ -280,43 +280,65 @@ async function isClientSource(src) {
 }
 
 /**
- * Extract `export const route = "name"` and detect `export const validate`
- * from a source file using AST parsing.
+ * Extract `export const route = "name"` and detect `export const validate` /
+ * `export const matchers` from a source file using AST parsing.
  */
 async function extractRouteExports(src) {
   const { ast } = await parseFileAST(src);
-  if (!ast) return { name: null, hasValidate: false };
+  if (!ast) return { name: null, hasValidate: false, hasMatchers: false };
   const routeInit = findExportedConst(ast, "route");
   const name = getStringValue(routeInit);
   const hasValidate = findExportedConst(ast, "validate") !== null;
-  return { name, hasValidate };
+  const hasMatchers = findExportedConst(ast, "matchers") !== null;
+  return { name, hasValidate, hasMatchers };
 }
 
 /**
- * Derive a camelCase route name from a path like "/user/[id]/posts" → "userPosts".
+ * Derive a camelCase route name from a path.
+ *
+ *   "/user/[id]/posts"         → "userPosts"
+ *   "/product/[sku=uppercase]" → "productSkuUppercase"
+ *   "/docs/[...slug=nested]"   → "docsSlugNested"
+ *   "/[id]"                    → "id"
+ *
+ * Rule: a dynamic segment without a matcher alias is stripped (legacy
+ * behavior). A dynamic segment *with* a matcher alias contributes both its
+ * param name and the alias to the name, camelCased. This makes matcher-gated
+ * siblings name-distinct from their bare counterparts without needing numeric
+ * suffixes.
  */
 function deriveRouteName(path) {
   if (path === "/") return "index";
+  const cap = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
+  // Replace every `[...]`/`[[...]]` bracket with a name-contribution.
+  //   [name]            / [[name]]            → ""                 (strip)
+  //   [...name]         / [[...name]]         → ""                 (strip)
+  //   [name=alias]      / [[name=alias]]      → "<name><Alias>"    (include)
+  //   [...name=alias]   / [[...name=alias]]   → "<name><Alias>"    (include)
+  const replaceBrackets = (segment) =>
+    segment.replace(
+      /\[\[?\.{0,3}([^\]=]+)(?:=([^\]]+))?\]\]?/g,
+      (_, name, alias) => (alias ? `${name}${cap(alias)}` : "")
+    );
   const segments = path
     .replace(/^\//, "")
     .split("/")
-    .map((s) => s.replace(/\[\.{0,3}([^\]]+)\]/g, "").replace(/^@/, ""))
+    .map((s) => replaceBrackets(s).replace(/^@/, ""))
     .filter(Boolean);
   if (segments.length === 0) {
-    // Path is purely dynamic like "/[id]"
-    const dynamicSegments = path
+    // Purely dynamic path with no matchers (every bracket stripped to "").
+    // Fall back to the first bracket's param name so the route gets a name.
+    const first = path
       .replace(/^\//, "")
       .split("/")
       .map((s) => {
-        const m = s.match(/\[\.{0,3}([^\]]+)\]/);
+        const m = s.match(/\[\[?\.{0,3}([^\]=]+)/);
         return m ? m[1] : "";
       })
-      .filter(Boolean);
-    return dynamicSegments[0] ?? "index";
+      .filter(Boolean)[0];
+    return first ?? "index";
   }
-  return segments
-    .map((s, i) => (i === 0 ? s : s.charAt(0).toUpperCase() + s.slice(1)))
-    .join("");
+  return segments.map((s, i) => (i === 0 ? s : cap(s))).join("");
 }
 
 /**
@@ -513,6 +535,16 @@ export default function viteReactServerRouter(options = {}) {
     return paramCount;
   }
 
+  // Count matcher-gated bracket segments in a path (e.g. "[id=numeric]",
+  // "[...slug=nested]", "[[...slug=nested]]"). Used to rank more-specific
+  // routes ahead of less-specific siblings in the match order.
+  function getMatcherCount(path) {
+    let count = 0;
+    const re = /\[[^\]]*?=[^\]]*?\]/g;
+    while (re.exec(path) !== null) count++;
+    return count;
+  }
+
   function getRoutes(routes) {
     return routes
       .map(
@@ -622,6 +654,11 @@ export default function viteReactServerRouter(options = {}) {
           (aPath.includes("...") || bPath.includes("...")
             ? bPath.split("/").length - aPath.split("/").length
             : aPath.split("/").length - bPath.split("/").length) ||
+          // More matcher-gated segments = more specific → try first.
+          // Placed before localeCompare (which ignores punctuation under
+          // default CLDR collation and would otherwise rank "[sku]" ahead of
+          // "[sku=uppercase]", short-circuiting the matcher sibling).
+          getMatcherCount(bPath) - getMatcherCount(aPath) ||
           aPath.localeCompare(bPath) ||
           (bType === "page") - (aType === "page")
       );
@@ -752,12 +789,60 @@ export default function viteReactServerRouter(options = {}) {
         lines.push(`    ): typeof mapping;`);
       }
 
+      // Matchers — typed per alias present in the route path.
+      // Only emitted when the path contains at least one [param=alias] form,
+      // including catch-alls (which widen the signature to string[]).
+      const matcherAliases = extractMatcherAliases(path);
+      const matcherAliasEntries = Object.entries(matcherAliases);
+      if (matcherAliasEntries.length > 0) {
+        const matcherShape = matcherAliasEntries
+          .map(([alias, arity]) => `${alias}?: (value: ${arity}) => boolean`)
+          .join("; ");
+        lines.push(`    createMatchers(`);
+        lines.push(`      matchers: { ${matcherShape} }`);
+        lines.push(`    ): typeof matchers;`);
+      }
+
       lines.push(`  }`);
       lines.push(`  export const ${name}: ${interfaceName};\n`);
     }
 
     lines.push(`}`);
     return lines.join("\n");
+  }
+
+  /**
+   * Extract matcher aliases from a route path into an alias → arity map.
+   * e.g. "/user/[id=numeric]" → { numeric: "string" }
+   *      "/docs/[...slug=nested]" → { nested: "string[]" }
+   * Required and optional variants collapse to the same arity:
+   *   [id=a] / [[id=a]]           → "string"
+   *   [...id=a] / [[...id=a]]     → "string[]"
+   */
+  function extractMatcherAliases(path) {
+    const aliases = {};
+    // Normalize to inner contents per bracket, preserving "..." marker.
+    // Patterns to match, longest first:
+    //   [[...name=alias]]   optionalCatchAll
+    //   [...name=alias]     catchAll
+    //   [[name=alias]]      optionalParam
+    //   [name=alias]        param
+    const re =
+      /\[\[\.\.\.([^\]=]+)=([^\]]+)\]\]|\[\.\.\.([^\]=]+)=([^\]]+)\]|\[\[([^\]=]+)=([^\]]+)\]\]|\[([^\]=/]+)=([^\]/]+)\]/g;
+    let m;
+    while ((m = re.exec(path)) !== null) {
+      if (m[1] !== undefined) {
+        aliases[m[2]] = "string[]";
+      } else if (m[3] !== undefined) {
+        aliases[m[4]] = "string[]";
+      } else if (m[5] !== undefined) {
+        aliases[m[6]] = "string";
+      } else if (m[7] !== undefined) {
+        // If already string[], keep the wider type.
+        if (aliases[m[8]] !== "string[]") aliases[m[8]] = "string";
+      }
+    }
+    return aliases;
   }
 
   /**
@@ -774,7 +859,8 @@ export default function viteReactServerRouter(options = {}) {
     while ((m = regex.exec(path)) !== null) {
       const optional = m[0].startsWith("[[");
       const spread = m[0].includes("...");
-      const name = m[2];
+      // Strip matcher alias suffix (e.g. "id=numeric" → "id")
+      const name = m[2].split("=")[0];
       if (spread) {
         params.push(`${name}${optional ? "?" : ""}: string[]`);
       } else {
@@ -787,6 +873,28 @@ export default function viteReactServerRouter(options = {}) {
   // Cached route infos — invalidated on createManifest()
   let routeInfosCache = null;
   let routeInfosPromise = null;
+
+  // Per-src cache of whether the module exports `matchers`.
+  // Invalidated on createManifest() to pick up edits in dev.
+  const matchersExportCache = new Map();
+  async function hasMatchersExport(src) {
+    if (matchersExportCache.has(src)) return matchersExportCache.get(src);
+    // Virtual sources (prefixed) don't correspond to on-disk files we can AST-scan.
+    // Treat them as having no matchers export.
+    if (src.startsWith("\0") || src.includes("://")) {
+      matchersExportCache.set(src, false);
+      return false;
+    }
+    try {
+      const { ast } = await parseFileAST(src);
+      const result = !!ast && findExportedConst(ast, "matchers") !== null;
+      matchersExportCache.set(src, result);
+      return result;
+    } catch {
+      matchersExportCache.set(src, false);
+      return false;
+    }
+  }
 
   /**
    * Build route info objects: group manifest entries by path, extract route names,
@@ -869,13 +977,14 @@ export default function viteReactServerRouter(options = {}) {
         const mainPageSrc = pageEntries.find((e) => !e.outlet)?.src;
         const exports = mainPageSrc
           ? await extractRouteExports(mainPageSrc)
-          : { name: null, hasValidate: false };
+          : { name: null, hasValidate: false, hasMatchers: false };
         const name = exports.name ?? deriveRouteName(info.path);
         routeInfos.push({
           ...info,
           name,
           src: mainPageSrc,
           hasValidate: exports.hasValidate,
+          hasMatchers: exports.hasMatchers,
         });
       }
 
@@ -899,6 +1008,7 @@ export default function viteReactServerRouter(options = {}) {
     routeInfosCache = null;
     routeInfosPromise = null;
     clientPageCache.clear();
+    matchersExportCache.clear();
 
     if (viteCommand === "serve" && viteServer) {
       const manifestModule = viteServer.moduleGraph.getModuleById(
@@ -1844,6 +1954,7 @@ ${routeExportLines.join("\n")}
         const routeInfos = await buildRouteInfos();
         const exportLines = [];
         const lazyValidateLines = [];
+        const lazyMatchersLines = [];
         for (const info of routeInfos) {
           exportLines.push(
             `export const ${info.name} = __withHelpers(__createRoute("${info.path}"));`
@@ -1854,6 +1965,11 @@ ${routeExportLines.join("\n")}
             // so we can't statically import from page files here.
             lazyValidateLines.push(
               `import("${info.src}").then(__m => { ${info.name}.validate = __m.validate; });`
+            );
+          }
+          if (info.src && info.hasMatchers) {
+            lazyMatchersLines.push(
+              `import("${info.src}").then(__m => { ${info.name}.matchers = __m.matchers; });`
             );
           }
         }
@@ -1868,12 +1984,15 @@ function __withHelpers(descriptor) {
   descriptor.createLoading = __identity;
   descriptor.createFallback = __identity;
   descriptor.createResourceMapping = __identity;
+  descriptor.createMatchers = __identity;
   return descriptor;
 }
 
 ${exportLines.join("\n")}
 
 ${lazyValidateLines.join("\n")}
+
+${lazyMatchersLines.join("\n")}
 `;
       }
       if (id === "virtual:@lazarv/react-server/__resources__") {
@@ -1980,6 +2099,68 @@ ${lazyValidateLines.join("\n")}
           })
           .join(",\n");
 
+        // --- Matcher loaders -------------------------------------------------
+        // Collect (path, src) pairs for every routing participant that exports
+        // `matchers`: pages (non-resource), middlewares, and api routes.
+        // Layouts and error/loading/fallback boundaries are excluded — they
+        // don't participate in routing decisions via useMatch.
+        const matcherEntries = [];
+        for (const [src, path, , type] of manifest.pages) {
+          if (type === "resource") continue;
+          if (await hasMatchersExport(src)) {
+            matcherEntries.push([path, src]);
+          }
+        }
+        for (const [src, path] of manifest.middlewares) {
+          if (await hasMatchersExport(src)) {
+            matcherEntries.push([path, src]);
+          }
+        }
+        for (const apiRow of entry.api) {
+          const { src, _virtualPath } = apiRow;
+          // Derive the api route's path the same way the manifest row does.
+          let path = _virtualPath;
+          if (path === undefined) {
+            const normalized = apiRow.filename
+              .replace(/^\+*/g, "")
+              .replace(/\.\.\./g, "_dot_dot_dot_")
+              .replace(/(\{)[^}]*(\})/g, (m) => m.replace(/\./g, "_dot_"))
+              .split(".");
+            const [, name, ext] = apiEndpointRegExp.test(apiRow.filename)
+              ? normalized
+              : [
+                  "*",
+                  normalized[0] === "server" ? "" : normalized[0],
+                  normalized[0] === "server"
+                    ? ""
+                    : normalized.slice(1).join("."),
+                ];
+            path = `/${apiRow.directory}/${ext ? name : ""}`
+              .replace(/\/+$/g, "")
+              .replace(/_dot_dot_dot_/g, "...")
+              .replace(/_dot_/g, ".")
+              .replace(/(\{)([^}]*)(\})/g, "$2")
+              .replace(/^\/+/, "/");
+          }
+          if (await hasMatchersExport(src)) {
+            matcherEntries.push([path, src]);
+          }
+        }
+        // Deduplicate (same path + src can appear across manifest + outlet rows).
+        const matcherSeen = new Set();
+        const matcherLoaderEntries = matcherEntries
+          .filter(([path, src]) => {
+            const key = `${path}::${src}`;
+            if (matcherSeen.has(key)) return false;
+            matcherSeen.add(key);
+            return true;
+          })
+          .map(
+            ([path, src]) =>
+              `["${path}", async () => { const __m = await ${cachedImport(src)}; return __m.matchers; }]`
+          )
+          .join(",\n");
+
         // Generate cache variable declarations
         const cacheVarDecls = Array.from(importCacheMap.values())
           .map((v) => `let ${v};`)
@@ -1993,14 +2174,45 @@ ${lazyValidateLines.join("\n")}
           const routes = [
               ${routeEntries}
           ].toSorted(
-            ([aMethod, aPath], [bMethod, bPath]) =>
-              (aMethod === "*") - (bMethod === "*") ||
-              aPath.split("/").length - bPath.split("/").length ||
-              aPath.localeCompare(bPath)
+            ([aMethod, aPath], [bMethod, bPath]) => {
+              const aMatchers = (aPath.match(/\\[[^\\]]*?=[^\\]]*?\\]/g) || []).length;
+              const bMatchers = (bPath.match(/\\[[^\\]]*?=[^\\]]*?\\]/g) || []).length;
+              return (
+                (aMethod === "*") - (bMethod === "*") ||
+                aPath.split("/").length - bPath.split("/").length ||
+                bMatchers - aMatchers ||
+                aPath.localeCompare(bPath)
+              );
+            }
           );
           const pages = [
             ${pageEntries}
           ];
+
+          // Matcher loaders: [path, () => Promise<matchers>] for every
+          // routing participant that exports a \`matchers\` object. Paths not
+          // present here have no matchers; \`matchersFor(path)\` returns
+          // undefined and useMatch skips matcher evaluation.
+          const __matcherLoaders = [
+            ${matcherLoaderEntries}
+          ];
+          const __resolvedMatchers = new Map();
+          let __matchersLoadPromise = null;
+          function loadMatchers$() {
+            if (__matchersLoadPromise) return __matchersLoadPromise;
+            __matchersLoadPromise = Promise.all(
+              __matcherLoaders.map(async ([path, loader]) => {
+                const m = await loader();
+                if (m && typeof m === "object") {
+                  __resolvedMatchers.set(path, m);
+                }
+              })
+            );
+            return __matchersLoadPromise;
+          }
+          function matchersFor(path) {
+            return __resolvedMatchers.get(path);
+          }
 
           function warmup$() {
             return Promise.all([${Array.from(importCacheMap.keys())
@@ -2008,7 +2220,7 @@ ${lazyValidateLines.join("\n")}
               .join(", ")}]);
           }
 
-          export { middlewares, routes, pages, warmup$ };`;
+          export { middlewares, routes, pages, warmup$, loadMatchers$, matchersFor };`;
         return code;
       } else if (id.startsWith("virtual:__react_server_router_page__")) {
         let [path, src] = id
@@ -2143,6 +2355,7 @@ ${lazyValidateLines.join("\n")}
             viteCommand === "build" ? "MANIFEST, " : ""
           }COLLECT_STYLESHEETS, STYLES_CONTEXT, COLLECT_CLIENT_MODULES, CLIENT_MODULES_CONTEXT, POSTPONE_CONTEXT } from "@lazarv/react-server/server/symbols.mjs";
           import { useMatch } from "@lazarv/react-server/router";
+          import { matchersFor } from "@lazarv/react-server/file-router/manifest";
           ${hasClientRoutes || hasResources || clientSiblings.length > 0 ? `import { Route } from "@lazarv/react-server/router";` : ""}
           ${
             errorBoundaries.length > 0
@@ -2385,7 +2598,7 @@ ${lazyValidateLines.join("\n")}
               const match = [];
               const pages = components.filter(([, , , type]) => type === "page");
               for (const [src, path, outlet, type] of pages){
-                const params = useMatch(path, { exact: true });
+                const params = useMatch(path, { exact: true, matchers: matchersFor(path) });
                 if (params) {
                   match.push({
                     src,

--- a/packages/react-server/lib/route-match.mjs
+++ b/packages/react-server/lib/route-match.mjs
@@ -83,16 +83,20 @@ export function parse(path) {
     } else if (token.type === "param") {
       const value = token.value.slice(1, -1);
       if (value.startsWith("...")) {
+        const [param, matcher] = value.slice(3).split("=");
         currentSegment.push({
           type: "catchAll",
-          param: value.slice(3),
+          param,
+          matcher,
           start: token.start,
           end: token.end,
         });
       } else if (value.startsWith("[...") && value.endsWith("]")) {
+        const [param, matcher] = value.slice(4, -1).split("=");
         currentSegment.push({
           type: "optionalCatchAll",
-          param: value.slice(4, -1),
+          param,
+          matcher,
           start: token.start,
           end: token.end,
         });
@@ -192,9 +196,9 @@ export function match(route, path, options = {}) {
           }
           if (
             part.matcher &&
-            typeof options.matchers[part.matcher] === "function"
+            typeof options.matchers?.[part.matcher] === "function"
           ) {
-            const matcher = options.matchers[part.matcher];
+            const matcher = options.matchers?.[part.matcher];
             if (!matcher(paramValue)) {
               if (part.type === "param") {
                 return null;
@@ -224,9 +228,9 @@ export function match(route, path, options = {}) {
           }
           if (
             part.matcher &&
-            typeof options.matchers[part.matcher] === "function"
+            typeof options.matchers?.[part.matcher] === "function"
           ) {
-            const matcher = options.matchers[part.matcher];
+            const matcher = options.matchers?.[part.matcher];
             if (!matcher(pathSegments[pathIndex])) {
               segmentMatch = false;
               break;
@@ -238,8 +242,8 @@ export function match(route, path, options = {}) {
           if (pathIndex < pathSegments.length) {
             if (
               !part.matcher ||
-              (typeof options.matchers[part.matcher] === "function" &&
-                options.matchers[part.matcher](pathSegments[pathIndex]))
+              (typeof options.matchers?.[part.matcher] === "function" &&
+                options.matchers?.[part.matcher](pathSegments[pathIndex]))
             ) {
               consumedOptionalParams.push(part);
               segmentParams[part.param] = pathSegments[pathIndex];
@@ -250,6 +254,7 @@ export function match(route, path, options = {}) {
           part.type === "catchAll" ||
           part.type === "optionalCatchAll"
         ) {
+          const catchAllStart = pathIndex;
           const remainingPath = pathSegments.slice(pathIndex);
           if (routeIndex < routeSegments.length - 1) {
             const nextStaticSegment = routeSegments
@@ -282,6 +287,22 @@ export function match(route, path, options = {}) {
           ) {
             segmentMatch = false;
             break;
+          }
+
+          if (
+            part.matcher &&
+            typeof options.matchers?.[part.matcher] === "function" &&
+            Array.isArray(segmentParams[part.param]) &&
+            segmentParams[part.param].length > 0 &&
+            !options.matchers[part.matcher](segmentParams[part.param])
+          ) {
+            if (part.type === "catchAll") {
+              segmentMatch = false;
+              break;
+            }
+            // optionalCatchAll rejection: rewind and treat as absent
+            segmentParams[part.param] = [];
+            pathIndex = catchAllStart;
           }
         }
       }

--- a/test/__test__/apps/typed-file-router.spec.mjs
+++ b/test/__test__/apps/typed-file-router.spec.mjs
@@ -45,6 +45,11 @@ describe("typed-file-router — basic routes", () => {
     expect(navText).toContain("About");
     expect(navText).toContain("User 42");
     expect(navText).toContain("Dashboard");
+    // Nav includes matcher-gated demo routes
+    expect(navText).toContain("Product ABC-123");
+    expect(navText).toContain("Product abc-123");
+    expect(navText).toContain("Docs nested");
+    expect(navText).toContain("Docs flat");
   });
 });
 
@@ -274,6 +279,95 @@ describe("typed-file-router — route matchers", () => {
       "matched=[...slug]"
     );
     expect(await page.textContent('[data-testid="slug"]')).toBe("intro");
+  });
+
+  // Typed Link href construction — these asserts lock in the buildHref fix
+  // for matcher-aliased brackets. Before the fix, an alias-gated bracket was
+  // left verbatim in the emitted href (e.g. `/product/[sku=uppercase]`).
+  test("typed Link for [sku=uppercase] emits concrete URL with substituted params", async () => {
+    await page.goto(hostname);
+    await page.waitForLoadState("load");
+    const link = await page.$('nav a[href="/product/ABC-123"]');
+    expect(link).not.toBeNull();
+    expect(await link.textContent()).toContain("Product ABC-123");
+  });
+
+  test("typed Link for [sku] fallback emits concrete URL with substituted params", async () => {
+    await page.goto(hostname);
+    await page.waitForLoadState("load");
+    const link = await page.$('nav a[href="/product/abc-123"]');
+    expect(link).not.toBeNull();
+    expect(await link.textContent()).toContain("Product abc-123");
+  });
+
+  test("typed Link for [...slug=nested] joins array params into a concrete URL", async () => {
+    await page.goto(hostname);
+    await page.waitForLoadState("load");
+    const link = await page.$('nav a[href="/docs/getting-started/install"]');
+    expect(link).not.toBeNull();
+    expect(await link.textContent()).toContain("Docs nested");
+  });
+
+  test("typed Link for [...slug] catch-all joins a single segment into a URL", async () => {
+    await page.goto(hostname);
+    await page.waitForLoadState("load");
+    const link = await page.$('nav a[href="/docs/intro"]');
+    expect(link).not.toBeNull();
+    expect(await link.textContent()).toContain("Docs flat");
+  });
+
+  // Client-side navigation — verifies matcher dispatch still runs correctly
+  // after hydration, not just on initial SSR. The cross-link on each demo
+  // page points at its sibling; clicking must re-match against the matcher.
+  test("client-side navigation from matcher page to fallback sibling re-runs matcher dispatch", async () => {
+    await page.goto(`${hostname}/product/ABC-123`);
+    await page.waitForLoadState("load");
+    await waitForHydration();
+
+    const prevUrl = page.url();
+    const fallbackLink = await page.$('a[href="/product/abc-123"]');
+    expect(fallbackLink).not.toBeNull();
+    await fallbackLink.click();
+    await waitForChange(null, () => page.url(), prevUrl);
+
+    expect(page.url()).toContain("/product/abc-123");
+    expect(await page.textContent('[data-testid="route"]')).toBe(
+      "matched=[sku]"
+    );
+  });
+
+  test("client-side navigation from fallback back to matcher page", async () => {
+    await page.goto(`${hostname}/product/abc-123`);
+    await page.waitForLoadState("load");
+    await waitForHydration();
+
+    const prevUrl = page.url();
+    const matcherLink = await page.$('a[href="/product/ABC-123"]');
+    expect(matcherLink).not.toBeNull();
+    await matcherLink.click();
+    await waitForChange(null, () => page.url(), prevUrl);
+
+    expect(page.url()).toContain("/product/ABC-123");
+    expect(await page.textContent('[data-testid="route"]')).toBe(
+      "matched=[sku=uppercase]"
+    );
+  });
+
+  test("client-side navigation from flat docs fallback to nested docs matcher", async () => {
+    await page.goto(`${hostname}/docs/intro`);
+    await page.waitForLoadState("load");
+    await waitForHydration();
+
+    const prevUrl = page.url();
+    const nestedLink = await page.$('a[href="/docs/getting-started/install"]');
+    expect(nestedLink).not.toBeNull();
+    await nestedLink.click();
+    await waitForChange(null, () => page.url(), prevUrl);
+
+    expect(page.url()).toContain("/docs/getting-started/install");
+    expect(await page.textContent('[data-testid="route"]')).toBe(
+      "matched=[...slug=nested]"
+    );
   });
 });
 

--- a/test/__test__/apps/typed-file-router.spec.mjs
+++ b/test/__test__/apps/typed-file-router.spec.mjs
@@ -235,6 +235,48 @@ describe("typed-file-router — resource routes", () => {
   });
 });
 
+// ── Route matchers ──
+
+describe("typed-file-router — route matchers", () => {
+  test("[sku=uppercase] matches uppercase SKU, sibling [sku] does not steal", async () => {
+    await page.goto(`${hostname}/product/ABC-123`);
+    await page.waitForLoadState("load");
+    expect(await page.textContent('[data-testid="route"]')).toBe(
+      "matched=[sku=uppercase]"
+    );
+    expect(await page.textContent('[data-testid="sku-upper"]')).toBe("ABC-123");
+  });
+
+  test("[sku=uppercase] rejects lowercase, [sku] catches the fallback", async () => {
+    await page.goto(`${hostname}/product/abc-123`);
+    await page.waitForLoadState("load");
+    expect(await page.textContent('[data-testid="route"]')).toBe(
+      "matched=[sku]"
+    );
+    expect(await page.textContent('[data-testid="sku-any"]')).toBe("abc-123");
+  });
+
+  test("[...slug=nested] matcher receives array, matches when length ≥ 2", async () => {
+    await page.goto(`${hostname}/docs/getting-started/install`);
+    await page.waitForLoadState("load");
+    expect(await page.textContent('[data-testid="route"]')).toBe(
+      "matched=[...slug=nested]"
+    );
+    expect(await page.textContent('[data-testid="slug"]')).toBe(
+      "getting-started/install"
+    );
+  });
+
+  test("[...slug=nested] rejects single segment, [...slug] catches fallback", async () => {
+    await page.goto(`${hostname}/docs/intro`);
+    await page.waitForLoadState("load");
+    expect(await page.textContent('[data-testid="route"]')).toBe(
+      "matched=[...slug]"
+    );
+    expect(await page.textContent('[data-testid="slug"]')).toBe("intro");
+  });
+});
+
 // ── Browser history ──
 
 describe("typed-file-router — browser history", () => {


### PR DESCRIPTION
The file-router's underlying `match()` primitive has long supported named parameter matchers via `[param=alias]` syntax, but the file-router itself never exposed a way for a dynamic page to actually register its own matcher predicates. This branch closes that gap: a page (or middleware or API route) can now `export const matchers = descriptor.createMatchers({ alias: (value) => … })` and the runtime applies those predicates during routing — before any page code loads. This lets sibling routes divide the same parameter slot by shape, for example pairing `/product/[sku=uppercase]` with a bare `/product/[sku]` fallback so that rejected SKUs fall through instead of 404ing. Matchers are a strictly routing-layer concern and complement the existing `validate` export, which only runs after a route has already been selected.

Along the way `buildHref` turned out to have its own latent bug: its regex used `\w+` inside the bracket, so it silently skipped both `[name=alias]` and every optional form (`[[name]]`, `[[...name]]`), leaving the raw bracket literal in the emitted URL. The replacement uses an explicit four-alternative regex with the alias suffix as an optional trailing group per form, strips the alias (it's a routing-time concern, not a URL concern), and collapses any `//` introduced by empty optional substitutions. Documentation in both English and Japanese, the typed-file-router example, and integration tests covering both required and catch-all matchers with their fall-through behavior are included so the whole story is reachable from the nav of the running example.
