### PR TITLE
feat: server functions validation

### DIFF
--- a/docs/src/pages/en/(pages)/guide/server-functions.mdx
+++ b/docs/src/pages/en/(pages)/guide/server-functions.mdx
@@ -342,6 +342,238 @@ export default function TodoApp() {
 
 The file is treated as a client component because of the top-level `"use client"` directive, but the `addItem` function is extracted into a separate server module. This works the same way as defining the Server Function in a standalone `"use server"` file — the runtime handles the extraction automatically.
 
+<Link name="validation">
+## Validation
+</Link>
+
+Server Functions accept arguments from the client. Any payload that flows from a browser into a server handler is, by definition, untrusted. The runtime offers an opt-in API — `createFunction` — that lets you declare a parse/validate contract for each runtime argument slot. The contract is enforced at the protocol layer: the decoder runs your `parse` and `validate` slot-by-slot during the args walk, and rejects the request on the first failure with HTTP 400 — *before* the handler runs, before any business logic touches the value, before any allocation that the handler might assume is bounded.
+
+Bare `"use server"` functions without `createFunction` keep working unchanged. The validation contract is opt-in and additive.
+
+<Link name="createfunction">
+### `createFunction`
+</Link>
+
+Wrap an action handler with `createFunction(spec)(handler)`. Pass the per-slot validate specs as an array — the most common shape:
+
+```jsx
+import {
+  createFunction,
+  formData,
+  file,
+} from "@lazarv/react-server/function";
+import { z } from "zod";
+
+export const updateProfile = createFunction([
+  z.string().email(),
+  z.string().min(2).max(80),
+])(async function updateProfile(email, name) {
+  "use server";
+  await db.users.update({ email, name });
+});
+```
+
+Index `i` in the array describes the **runtime arg slot `i`** — what the client puts on the wire at position `i`. It is *not* the handler's signature parameter `i`. Bound captures from `.bind(...)` or inline closures are not part of this contract — they're hidden values, integrity-protected by the AEAD action token, and never validated as user input.
+
+The runtime accepts any [Standard Schema](https://standardschema.dev/) — Zod, Valibot, ArkType — duck-typed via `safeParse` / `assert` / `parse`. You don't import a particular library from `@lazarv/react-server`; bring whichever schema library your project already uses.
+
+<Link name="parse-then-validate">
+### Parse, then validate
+</Link>
+
+When you also need pre-validate parsing, switch to the object form: `createFunction({ validate, parse })`. Both fields are arrays indexed by the same slot. `parse[i]` runs after the value tree is materialized but before `validate[i]` — the right place for type coercion that schemas can't easily express:
+
+```js
+export const setLimit = createFunction({
+  parse: [(v) => Number(v)],
+  validate: [z.number().int().min(1).max(1000)],
+})(async function setLimit(limit) {
+  "use server";
+  await db.config.set({ limit });
+});
+```
+
+A throwing `parse` surfaces as `DecodeValidationError(reason: "parse_failed")`; a failing `validate` surfaces as `reason: "validate_failed"`. The decoder aborts on the first failure — the next slot is never touched, the handler is never called.
+
+<Link name="noop-slot-marker">
+### Skipping slots with `noop`
+</Link>
+
+When only some slots need validation or parsing, use the `noop` export as a placeholder rather than reaching for sparse-array syntax (`[, , schema]`) or explicit `undefined`:
+
+```js
+import { createFunction, noop } from "@lazarv/react-server/function";
+
+export const update = createFunction([noop, noop, z.number().int()])(
+  async function update(a, b, count) {
+    // a: unknown, b: unknown, count: number — slots 0/1 are accepted
+    // unvalidated; slot 2 is the only one constrained.
+    "use server";
+  }
+);
+```
+
+Same idea in the object form when `parse` and `validate` need different gap patterns:
+
+```js
+createFunction({
+  parse:    [noop, noop, (v) => Number(v)],
+  validate: [z.string(), noop, z.number()],
+})(handler);
+// handler: (a: string, b: unknown, c: number)
+```
+
+`noop` is the identity transform — at runtime it's the same as omitting validation/parsing for that slot. Slots typed `noop` resolve to `unknown` in the inferred handler signature.
+
+<Link name="formdataarg">
+### `formData` — file uploads and structured forms
+</Link>
+
+`FormData` arguments are common when uploading files or submitting progressive-enhancement forms. Schema libraries can describe object shapes, but they describe *materialized* values — by the time a schema runs, the file is already buffered. `formData` is wire-aware: the decoder enforces declared keys and per-entry constraints *during* the FormData walk, so size and MIME limits are checked synchronously against `Blob.size` / `Blob.type` before the entry is added to the result.
+
+```js
+import {
+  createFunction,
+  formData,
+  file,
+} from "@lazarv/react-server/function";
+
+export const upload = createFunction([
+  formData({
+    title: z.string().min(1).max(120),
+    photo: file({
+      maxBytes: 5 * 1024 * 1024,
+      mime: ["image/png", "image/jpeg"],
+    }),
+  }),
+])(async function upload(form) {
+  "use server";
+  const title = form.get("title");
+  const photo = form.get("photo");
+  // photo is already size- and MIME-checked.
+});
+```
+
+`formData(shape, options?)` takes the entry shape as its first argument and an optional config bag as its second. The shape is required; the only option today is `unknown`, but the slot is reserved for future per-form constraints.
+
+The decoder looks up declared entries by **exact key**. There is no prefix scan, so an attacker-injected entry like `5_role=admin` cannot land in the FormData your handler reads.
+
+The `unknown` policy — passed as `formData(shape, { unknown: "drop" })` — controls what happens to entries that are *not* declared:
+
+- `"reject"` (default, recommended): an unknown entry fails the decode with `DecodeValidationError(reason: "unknown_entry")`. Defends against attacker-injected fields.
+- `"drop"`: silently skip undeclared entries. Useful when the form includes React-managed hidden fields the schema doesn't enumerate.
+- `"allow"`: copy undeclared entries through unvalidated. Escape hatch — documented as unsafe.
+
+`file({...})` and `blob({...})` accept `maxBytes` (per-entry size cap), `mime` (allowlist of acceptable MIME types), an optional sync `validate(value)` callback for custom checks (e.g. magic-byte detection), and `optional: true` to allow a missing entry. `File.type` is browser-supplied and trivially spoofable — combine MIME with magic-byte detection in `validate` for hard guarantees.
+
+<Link name="other-wire-types">
+### Other wire types
+</Link>
+
+The Flight protocol carries more than just primitives, objects, and `FormData`. For each remaining wire type where a Standard Schema isn't enough on its own — usually because validation needs to bound resource consumption, type-check against a platform constructor, or wrap an async source — there's a dedicated wire-aware helper:
+
+```js
+import {
+  createFunction,
+  arrayBuffer,
+  typedArray,
+  map,
+  set,
+  stream,
+  asyncIterable,
+  iterable,
+  promise,
+} from "@lazarv/react-server/function";
+```
+
+| Helper | Wire tag | Handler-side type | Why it's wire-aware |
+|---|---|---|---|
+| `arrayBuffer({ maxBytes })` | `$AB` | `ArrayBuffer` | Byte-length cap before the handler observes the buffer |
+| `typedArray({ ctor, maxBytes })` | `$AT` | `InstanceType<C>` (e.g. `Float32Array`) | Constructor allowlist via `instanceof`; type narrowed in inference |
+| `map({ maxSize, key, value })` | `$Q` | `Map<K, V>` | Size cap; inner key/value schemas |
+| `set({ maxSize, value })` | `$W` | `Set<T>` | Size cap; per-item schema |
+| `stream({ maxChunks, maxBytes })` | `$r` / `$b` | `ReadableStream` | Bounds enforced as the handler consumes the stream |
+| `asyncIterable({ maxYields, value })` | `$x` | `AsyncIterable<T>` | Yield ceiling + per-yield validation |
+| `iterable({ maxYields, value })` | `$X` | `Iterable<T>` | Same, sync flavor |
+| `promise(value)` | `$@` | `Promise<T>` | Resolved-value validation through the schema |
+
+A few examples in context:
+
+```js
+// Binary upload arriving as a typed array
+export const upload = createFunction([
+  typedArray({ ctor: Uint8Array, maxBytes: 5 * 1024 * 1024 }),
+])(async function upload(bytes) {
+  "use server";
+  // bytes: Uint8Array, already size-checked
+});
+
+// Bounded Map argument
+export const lookup = createFunction([
+  map({ maxSize: 100, key: z.string(), value: z.number() }),
+])(async function lookup(table) {
+  "use server";
+  // table: Map<string, number>, capped at 100 entries
+});
+
+// Streaming upload with a per-stream byte cap
+export const ingest = createFunction([
+  stream({ maxBytes: 50 * 1024 * 1024, maxChunks: 8192 }),
+])(async function ingest(stream) {
+  "use server";
+  // stream: ReadableStream — wrapped to error if either ceiling is exceeded
+  for await (const chunk of stream) { … }
+});
+
+// Bounded async iterable with per-yield validation
+export const events = createFunction([
+  asyncIterable({
+    maxYields: 1000,
+    value: z.object({ type: z.string(), payload: z.unknown() }),
+  }),
+])(async function events(stream) {
+  "use server";
+  // stream: AsyncIterable<{type: string, payload: unknown}>
+});
+```
+
+Each helper rejects at decode with a distinct `reason` code:
+
+- `wire_shape_mismatch` — slot's wire tag doesn't match the spec (e.g. expected `$AT` got a primitive)
+- `max_bytes_exceeded` / `max_size_exceeded` / `max_chunks_exceeded` / `max_yields_exceeded` — resource ceiling tripped
+- `validate_failed` — inner Standard Schema rejected a key, value, or yielded item
+
+For streams and iterables, the bound is enforced **as the handler consumes them**, not at decode time. The decoder wraps the materialized stream / iterable; once the handler reads past the ceiling the wrapper errors instead of yielding more data. That matters because Flight materializes stream chunks up-front at decode — the wrap is what lets per-slot bounds tighten beyond the global `maxStreamChunks` ceiling.
+
+`typedArray` takes the actual constructor reference (not a string name): `typedArray({ ctor: Float32Array })` infers as `(samples: Float32Array)` in the handler, and the runtime check is `value instanceof Float32Array`. Pass an array of constructors for a union: `typedArray({ ctor: [Uint8Array, Uint8ClampedArray] })`.
+
+<Link name="dev-strict-mode">
+### Dev-time warnings
+</Link>
+
+In development, every Server Function call without a `createFunction` contract logs a one-time warning to the server console:
+
+> Server function `src/actions/upload.mjs#upload` called without validation — wrap the export with `createFunction({...})(handler)` from `@lazarv/react-server/function` (set `config.serverFunctions.strict = false` to silence) 🛡️
+
+The action id format matches what the runtime uses internally (`<modulePath>#<exportName>`), so you can grep straight to the source. The warning is per-action and per-process: each unwrapped action is named once, no matter how many times it's called.
+
+This is purely a dev guardrail — built/started servers never log it. If you're migrating an existing codebase incrementally and don't want the noise, set `config.serverFunctions.strict = false`:
+
+```js
+// react-server.config.mjs
+export default {
+  serverFunctions: { strict: false },
+};
+```
+
+<Link name="error-handling">
+### Error handling
+</Link>
+
+When validation fails, the runtime returns HTTP 400 and sets the `x-react-server-action-error` header to the failure reason (`validate_failed`, `parse_failed`, `unknown_entry`, `max_bytes_exceeded`, `mime_not_allowed`, `missing_entry`, `wire_shape_mismatch`, `custom_validate_failed`, `duplicate_entry`). The client receives a generic error — schema diagnostics are not forwarded to avoid leaking expected-shape details that aid attackers. Diagnostics are written to the server log via `logger.warn` for operator visibility.
+
+If you need user-facing error messages tied to specific fields, validate the same payload again *inside* the handler and return a structured error object: that path is yours to design and is what `useActionState` is built around.
+
 <Link name="security">
 ## Security
 </Link>

--- a/docs/src/pages/ja/(pages)/guide/server-functions.mdx
+++ b/docs/src/pages/ja/(pages)/guide/server-functions.mdx
@@ -202,6 +202,238 @@ export default function App() {
 }
 ```
 
+<Link name="validation">
+## バリデーション
+</Link>
+
+サーバ関数はクライアントから引数を受け取ります。ブラウザからサーバのハンドラに流れ込むペイロードは、定義上「信頼されない」ものです。ランタイムはオプトインの API として `createFunction` を提供し、ランタイムの各引数スロットに対して parse / validate のコントラクトを宣言できます。このコントラクトはプロトコル層で適用されます。デコーダは引数ウォークの間にスロットごとに `parse` と `validate` を実行し、最初に失敗したスロットでリクエストを HTTP 400 として拒否します。これはハンドラが走る *前*、ビジネスロジックが値に触れる *前*、ハンドラが境界を仮定するアロケーションが起きる *前* です。
+
+`createFunction` で包まれていないベアな `"use server"` 関数は、これまで通り変更なく動作します。バリデーションコントラクトはオプトインで追加的なものです。
+
+<Link name="createfunction">
+### `createFunction`
+</Link>
+
+アクションハンドラを `createFunction(spec)(handler)` で包みます。バリデートのスロットを配列で渡すのが一番よくある形です。
+
+```jsx
+import {
+  createFunction,
+  formData,
+  file,
+} from "@lazarv/react-server/function";
+import { z } from "zod";
+
+export const updateProfile = createFunction([
+  z.string().email(),
+  z.string().min(2).max(80),
+])(async function updateProfile(email, name) {
+  "use server";
+  await db.users.update({ email, name });
+});
+```
+
+配列の `i` 番目は **ランタイム引数スロット `i`** を記述します。これはクライアントがワイヤ上の位置 `i` に置く値であり、ハンドラのシグネチャの引数 `i` ではありません。`.bind(...)` やインラインクロージャによるバウンドキャプチャはこのコントラクトの一部ではありません。これらは隠された値であり、AEAD のアクショントークンによって完全性が保護され、ユーザ入力としてバリデートされることはありません。
+
+ランタイムは [Standard Schema](https://standardschema.dev/) — Zod、Valibot、ArkType — を `safeParse` / `assert` / `parse` の duck-type で受け付けます。特定のライブラリを `@lazarv/react-server` からインポートする必要はありません。プロジェクトで既に使っているスキーマライブラリを持ち込んでください。
+
+<Link name="parse-then-validate">
+### parse のあとに validate
+</Link>
+
+事前のパースも必要な場合は、オブジェクト形式 `createFunction({ validate, parse })` に切り替えます。両方とも同じスロットでインデックスされる配列です。`parse[i]` は値ツリーがマテリアライズされた後、`validate[i]` の前に実行されます。スキーマでは表現しにくい型変換を入れるのに適しています。
+
+```js
+export const setLimit = createFunction({
+  parse: [(v) => Number(v)],
+  validate: [z.number().int().min(1).max(1000)],
+})(async function setLimit(limit) {
+  "use server";
+  await db.config.set({ limit });
+});
+```
+
+`parse` が例外を投げると `DecodeValidationError(reason: "parse_failed")` として現れ、`validate` の失敗は `reason: "validate_failed"` になります。デコーダは最初の失敗で中断します。次のスロットには触れず、ハンドラも呼ばれません。
+
+<Link name="noop-slot-marker">
+### `noop` で特定のスロットだけスキップする
+</Link>
+
+一部のスロットだけバリデーション / パースをかけたい場合は、スパース配列の `[, , schema]` や明示的な `undefined` ではなく、`noop` エクスポートをプレースホルダとして使います。
+
+```js
+import { createFunction, noop } from "@lazarv/react-server/function";
+
+export const update = createFunction([noop, noop, z.number().int()])(
+  async function update(a, b, count) {
+    // a: unknown, b: unknown, count: number
+    // — スロット 0 / 1 は未検証で受け入れ、スロット 2 のみ制約あり。
+    "use server";
+  }
+);
+```
+
+オブジェクト形式で `parse` と `validate` のギャップが揃っていないときも同じです。
+
+```js
+createFunction({
+  parse:    [noop, noop, (v) => Number(v)],
+  validate: [z.string(), noop, z.number()],
+})(handler);
+// handler: (a: string, b: unknown, c: number)
+```
+
+`noop` は恒等変換です。ランタイム上はそのスロットの validation / parse を省くのと同じ挙動になります。`noop` が当たるスロットは、ハンドラのシグネチャ推論では `unknown` になります。
+
+<Link name="formdataarg">
+### `formData` — ファイルアップロードと構造化フォーム
+</Link>
+
+`FormData` 引数はファイルアップロードや progressive enhancement のフォーム送信でよく使われます。スキーマライブラリはオブジェクトの形を記述できますが、それは *マテリアライズ済みの* 値です。スキーマが走る時点で、ファイルはすでにバッファされています。`formData` はワイヤ・アウェアです。デコーダは FormData ウォークの *最中* に宣言済みのキーと各エントリの制約を強制するため、サイズと MIME の制限はエントリが結果に追加される前に `Blob.size` / `Blob.type` に対して同期的にチェックされます。
+
+```js
+import {
+  createFunction,
+  formData,
+  file,
+} from "@lazarv/react-server/function";
+
+export const upload = createFunction([
+  formData({
+    title: z.string().min(1).max(120),
+    photo: file({
+      maxBytes: 5 * 1024 * 1024,
+      mime: ["image/png", "image/jpeg"],
+    }),
+  }),
+])(async function upload(form) {
+  "use server";
+  const title = form.get("title");
+  const photo = form.get("photo");
+  // photo はサイズと MIME がすでにチェックされています。
+});
+```
+
+`formData(shape, options?)` は第 1 引数にエントリのシェイプ(必須)、第 2 引数にオプション(任意)を取ります。今のところオプションは `unknown` のみですが、将来のフォーム単位制約のために予約されたスロットです。
+
+デコーダは宣言済みのエントリを **完全一致のキー** で参照します。プレフィックススキャンは行われないので、`5_role=admin` のような攻撃者注入のエントリがハンドラの読む FormData に紛れ込むことはありません。
+
+`unknown` ポリシーは `formData(shape, { unknown: "drop" })` のように第 2 引数で渡し、シェイプで *宣言されていない* エントリの扱いを決めます。
+
+- `"reject"`(デフォルト、推奨): 未知のエントリは `DecodeValidationError(reason: "unknown_entry")` でデコードを失敗させます。攻撃者注入フィールドへの防御です。
+- `"drop"`: 宣言外のエントリを黙って捨てます。React 管理の隠しフィールドなど、スキーマで列挙したくない場合に有用です。
+- `"allow"`: 宣言外のエントリを未検証のまま素通りさせます。エスケープハッチであり、安全ではないものとしてドキュメント化しています。
+
+`file({...})` と `blob({...})` は `maxBytes`(エントリごとのサイズ上限)、`mime`(許容 MIME のホワイトリスト)、オプションの同期 `validate(value)` コールバック(マジックバイト検査などのカスタムチェック)、不在を許す `optional: true` を受け付けます。`File.type` はブラウザが供給する値で、簡単に偽装できます。MIME チェックを `validate` でのマジックバイト検査と組み合わせて、強い保証を得てください。
+
+<Link name="other-wire-types">
+### その他のワイヤ型
+</Link>
+
+Flight プロトコルはプリミティブやオブジェクト、`FormData` 以外にもさまざまな型を運びます。Standard Schema 単体では足りないワイヤ型 — リソース消費を制限したい、プラットフォームのコンストラクタで型チェックしたい、非同期ソースをラップしたい場合 — それぞれにワイヤ・アウェアなヘルパーを用意しています。
+
+```js
+import {
+  createFunction,
+  arrayBuffer,
+  typedArray,
+  map,
+  set,
+  stream,
+  asyncIterable,
+  iterable,
+  promise,
+} from "@lazarv/react-server/function";
+```
+
+| ヘルパー | ワイヤタグ | ハンドラ側の型 | ワイヤ・アウェアである理由 |
+|---|---|---|---|
+| `arrayBuffer({ maxBytes })` | `$AB` | `ArrayBuffer` | ハンドラがバッファを観測する前にバイト長を制限 |
+| `typedArray({ ctor, maxBytes })` | `$AT` | `InstanceType<C>`(例: `Float32Array`) | `instanceof` でコンストラクタを許可制に。型推論にも反映 |
+| `map({ maxSize, key, value })` | `$Q` | `Map<K, V>` | サイズ制限・内側のキー/値スキーマ |
+| `set({ maxSize, value })` | `$W` | `Set<T>` | サイズ制限・要素ごとのスキーマ |
+| `stream({ maxChunks, maxBytes })` | `$r` / `$b` | `ReadableStream` | ハンドラがストリームを消費する間に上限を強制 |
+| `asyncIterable({ maxYields, value })` | `$x` | `AsyncIterable<T>` | yield 数の上限・yield ごとのバリデーション |
+| `iterable({ maxYields, value })` | `$X` | `Iterable<T>` | 同期版で同じ仕組み |
+| `promise(value)` | `$@` | `Promise<T>` | 解決値をスキーマで検証 |
+
+具体例:
+
+```js
+// 型付き配列として届くバイナリアップロード
+export const upload = createFunction([
+  typedArray({ ctor: Uint8Array, maxBytes: 5 * 1024 * 1024 }),
+])(async function upload(bytes) {
+  "use server";
+  // bytes: Uint8Array、サイズ済みチェック済み
+});
+
+// 制限付き Map 引数
+export const lookup = createFunction([
+  map({ maxSize: 100, key: z.string(), value: z.number() }),
+])(async function lookup(table) {
+  "use server";
+  // table: Map<string, number>、エントリ数 100 でキャップ
+});
+
+// ストリームごとのバイト数キャップ
+export const ingest = createFunction([
+  stream({ maxBytes: 50 * 1024 * 1024, maxChunks: 8192 }),
+])(async function ingest(stream) {
+  "use server";
+  // stream: ReadableStream — どちらかの上限を超えるとエラーをスロー
+  for await (const chunk of stream) { … }
+});
+
+// yield ごとに検証する非同期イテラブル
+export const events = createFunction([
+  asyncIterable({
+    maxYields: 1000,
+    value: z.object({ type: z.string(), payload: z.unknown() }),
+  }),
+])(async function events(stream) {
+  "use server";
+  // stream: AsyncIterable<{type: string, payload: unknown}>
+});
+```
+
+各ヘルパーはデコード時に異なる `reason` で拒否します。
+
+- `wire_shape_mismatch` — スロットのワイヤタグが仕様と一致しない(例: `$AT` を期待したのにプリミティブ)
+- `max_bytes_exceeded` / `max_size_exceeded` / `max_chunks_exceeded` / `max_yields_exceeded` — リソース上限超過
+- `validate_failed` — 内側の Standard Schema がキー / 値 / yielded 要素を拒否
+
+ストリームとイテラブルでは、上限は **ハンドラが消費する時点** で強制されます。デコーダはマテリアライズしたストリーム / イテラブルをラップし、ハンドラが上限を超えて読みに行った瞬間にラッパーが値を流す代わりにエラーを発生させます。Flight プロトコルはチャンクをデコード時に先読みするため、このラッパーがあって初めてグローバルな `maxStreamChunks` 上限よりタイトなスロット単位の制限が効きます。
+
+`typedArray` は文字列名ではなく **コンストラクタの参照** を取ります。`typedArray({ ctor: Float32Array })` でハンドラの型が `(samples: Float32Array)` に推論され、ランタイムの判定は `value instanceof Float32Array` です。複数許可したい場合は配列で: `typedArray({ ctor: [Uint8Array, Uint8ClampedArray] })`。
+
+<Link name="dev-strict-mode">
+### 開発時の警告
+</Link>
+
+開発時には、`createFunction` のコントラクトを持たないサーバ関数の呼び出しごとに、サーバコンソールへ一度だけ警告が記録されます。
+
+> Server function `src/actions/upload.mjs#upload` called without validation — wrap the export with `createFunction({...})(handler)` from `@lazarv/react-server/function` (set `config.serverFunctions.strict = false` to silence) 🛡️
+
+アクション ID のフォーマットはランタイムが内部で使うもの(`<modulePath>#<exportName>`)と一致するので、grep でそのままソースに飛べます。警告はアクション単位・プロセス単位で 1 回だけです。同じアクションを何度呼び出しても、名前が出るのは最初の一回だけです。
+
+これは純粋に開発時のガードレールです。ビルド・起動後のサーバではログに出ません。既存コードベースを段階的に移行している最中でノイズを止めたい場合は、`config.serverFunctions.strict = false` を設定してください。
+
+```js
+// react-server.config.mjs
+export default {
+  serverFunctions: { strict: false },
+};
+```
+
+<Link name="error-handling">
+### エラーハンドリング
+</Link>
+
+バリデーションが失敗するとランタイムは HTTP 400 を返し、`x-react-server-action-error` ヘッダに失敗理由(`validate_failed`、`parse_failed`、`unknown_entry`、`max_bytes_exceeded`、`mime_not_allowed`、`missing_entry`、`wire_shape_mismatch`、`custom_validate_failed`、`duplicate_entry`)を入れます。クライアントには汎用的なエラーが届きます。期待されるシェイプの詳細を攻撃者に漏らさないため、スキーマの診断はクライアントに転送しません。診断はサーバログに `logger.warn` で書き出され、運用者が確認できます。
+
+特定のフィールドに紐づいたユーザ向けエラーメッセージが必要な場合は、ハンドラの *中* で同じペイロードに対してもう一度バリデーションし、構造化されたエラーオブジェクトを返してください。これは設計上あなたが扱う領域であり、`useActionState` がそのために用意されています。
+
 <Link name="security">
 ## セキュリティ
 </Link>

--- a/examples/typed-file-router/pages/(root).layout.tsx
+++ b/examples/typed-file-router/pages/(root).layout.tsx
@@ -6,6 +6,7 @@ import {
   counter,
   clock,
   todos,
+  guestbook,
   product,
   productSkuUppercase,
   docs,
@@ -37,6 +38,7 @@ export default index.createLayout(({ children }) => {
           <counter.Link>Counter</counter.Link>
           <clock.Link>Clock</clock.Link>
           <todos.Link>Todos</todos.Link>
+          <guestbook.Link>Guestbook</guestbook.Link>
           <productSkuUppercase.Link params={{ sku: "ABC-123" }}>
             Product ABC-123 (matcher)
           </productSkuUppercase.Link>

--- a/examples/typed-file-router/pages/guestbook.page.tsx
+++ b/examples/typed-file-router/pages/guestbook.page.tsx
@@ -1,0 +1,64 @@
+/**
+ * Guestbook page — server component reading entries directly, with a
+ * client island below for the `createFunction` actions.
+ *
+ * Demonstrates `createFunction` with Zod schemas in the file-router
+ * setup. The page itself is a server component (async, reads from the
+ * server-side store); the form is a client island that calls the
+ * typed actions and refreshes the parent on success.
+ */
+import { guestbook } from "@lazarv/react-server/routes";
+
+import { listEntries } from "../src/guestbook-actions";
+import DeleteEntryButton from "../src/DeleteEntryButton";
+import GuestbookForm from "../src/GuestbookForm";
+
+export const route = "guestbook";
+
+export default guestbook.createPage(async () => {
+  const entries = await listEntries();
+
+  return (
+    <div>
+      <h2>Guestbook</h2>
+      <p>
+        Server functions wrapped with{" "}
+        <code>createFunction([zod-schema])(handler)</code>. Validation runs at
+        the protocol layer — submit an empty message and the request returns
+        HTTP 400 with <code>x-react-server-action-error: validate_failed</code>{" "}
+        before the handler ever runs.
+      </p>
+
+      <ul style={{ listStyle: "none", padding: 0 }}>
+        {entries.length === 0 && (
+          <li style={{ color: "gray" }}>(no entries yet)</li>
+        )}
+        {entries.map((entry) => (
+          <li
+            key={entry.id}
+            data-testid={`guestbook-entry-${entry.id}`}
+            style={{
+              padding: "0.5rem 0.75rem",
+              border: "1px solid #eee",
+              borderRadius: 4,
+              marginBottom: "0.5rem",
+            }}
+          >
+            <div style={{ display: "flex", justifyContent: "space-between" }}>
+              <div>
+                <strong>{entry.name}</strong>
+                <DeleteEntryButton id={entry.id} />
+              </div>
+              <span style={{ color: "gray", fontSize: "0.8rem" }}>
+                {new Date(entry.createdAt).toLocaleString()}
+              </span>
+            </div>
+            <div style={{ marginTop: "0.25rem" }}>{entry.message}</div>
+          </li>
+        ))}
+      </ul>
+
+      <GuestbookForm />
+    </div>
+  );
+});

--- a/examples/typed-file-router/src/DeleteEntryButton.tsx
+++ b/examples/typed-file-router/src/DeleteEntryButton.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useTransition } from "react";
+import { useClient } from "@lazarv/react-server/client";
+import { deleteEntry } from "./guestbook-actions";
+
+/**
+ * Tiny client island for the per-entry delete button.
+ *
+ * Each entry rendered by the server component
+ * (`pages/guestbook.page.tsx`) gets one of these next to it. The `id`
+ * arrives via props from the server — typed end-to-end as `number`,
+ * narrowed by Zod's `.coerce.number().int().positive()` at the action
+ * boundary.
+ *
+ * After a successful delete, the runtime's `refresh()` re-runs the
+ * parent server component so the list reflects the change.
+ */
+export default function DeleteEntryButton({ id }: { id: number }) {
+  const { refresh } = useClient();
+  const [pending, startTransition] = useTransition();
+
+  return (
+    <button
+      type="button"
+      disabled={pending}
+      data-testid={`guestbook-delete-${id}`}
+      onClick={() =>
+        startTransition(async () => {
+          await deleteEntry(id);
+          await refresh();
+        })
+      }
+      style={{
+        marginLeft: "0.5rem",
+        padding: "0.1rem 0.5rem",
+        fontSize: "0.75rem",
+        color: "crimson",
+        background: "transparent",
+        border: "1px solid currentColor",
+        borderRadius: 3,
+        cursor: pending ? "wait" : "pointer",
+      }}
+    >
+      {pending ? "…" : "delete"}
+    </button>
+  );
+}

--- a/examples/typed-file-router/src/GuestbookForm.tsx
+++ b/examples/typed-file-router/src/GuestbookForm.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useClient } from "@lazarv/react-server/client";
+// Hover over each in your editor:
+//
+//   addEntry:    (input: { name: string; message: string }) => Promise<GuestbookEntry>
+//   deleteEntry: (id: number) => Promise<{ id: number; deleted: boolean }>
+//
+// Both signatures are inferred from the Zod schemas in
+// `src/guestbook-actions.ts` via the `InferArgs` machinery.
+import { addEntry, deleteEntry } from "./guestbook-actions";
+
+/**
+ * Client island that drives the createFunction-wrapped actions.
+ *
+ * Three sections:
+ *
+ *   1. The add form — a normal happy-path submission.
+ *   2. The "try a bad payload" panel — three buttons that build inputs
+ *      passing TypeScript's check but failing the Zod schema at the
+ *      protocol layer. The runtime rejects with HTTP 400 and the
+ *      handler never runs; the rejection surfaces as a thrown error
+ *      that the catch block displays to make the rejection visible.
+ *
+ * After every successful mutation we call `refresh()` from
+ * `useClient()` so the parent server component re-renders and the
+ * updated list flows back via RSC.
+ */
+export default function GuestbookForm() {
+  const { refresh } = useClient();
+  const [pending, startTransition] = useTransition();
+  const [lastError, setLastError] = useState<string | null>(null);
+  const [lastOk, setLastOk] = useState<string | null>(null);
+
+  const run = (label: string, fn: () => Promise<unknown>, after?: () => void) =>
+    startTransition(async () => {
+      setLastError(null);
+      setLastOk(null);
+      try {
+        await fn();
+        setLastOk(`${label} succeeded`);
+        after?.();
+      } catch (err) {
+        setLastError(
+          `${label} → ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    });
+
+  return (
+    <section
+      style={{
+        marginTop: "2rem",
+        padding: "1rem",
+        border: "1px solid #ddd",
+        borderRadius: 6,
+      }}
+    >
+      <h3 style={{ marginTop: 0 }}>Add an entry</h3>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          // Capture synchronously — React nullifies `e.currentTarget`
+          // before the async transition body runs.
+          const form = e.currentTarget;
+          const fd = new FormData(form);
+          const name = String(fd.get("name") ?? "");
+          const message = String(fd.get("message") ?? "");
+          run(
+            "addEntry (form)",
+            () => addEntry({ name, message }),
+            () => {
+              form.reset();
+              return refresh();
+            }
+          );
+        }}
+        style={{ display: "grid", gap: "0.5rem", maxWidth: 480 }}
+      >
+        <input
+          name="name"
+          placeholder="Your name"
+          data-testid="guestbook-name"
+          required
+          style={{ padding: "0.4rem" }}
+        />
+        <textarea
+          name="message"
+          placeholder="Leave a message"
+          data-testid="guestbook-message"
+          required
+          rows={3}
+          style={{ padding: "0.4rem", fontFamily: "inherit" }}
+        />
+        <button
+          type="submit"
+          disabled={pending}
+          data-testid="guestbook-submit"
+          style={{ padding: "0.4rem 0.75rem", justifySelf: "start" }}
+        >
+          {pending ? "Saving…" : "Add entry"}
+        </button>
+      </form>
+
+      <h3 style={{ marginTop: "2rem" }}>Try a bad payload</h3>
+      <p style={{ fontSize: "0.85rem", color: "gray", marginTop: 0 }}>
+        Each button below builds an input that{" "}
+        <strong>passes TypeScript</strong> (the shape is valid) but{" "}
+        <strong>fails the Zod schema at the protocol layer</strong>. Watch the
+        Network tab in DevTools — every rejection is <code>HTTP 400</code> with{" "}
+        <code>x-react-server-action-error: validate_failed</code>, and the
+        handler never executes.
+      </p>
+
+      <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
+        <button
+          disabled={pending}
+          data-testid="guestbook-bad-empty-name"
+          onClick={() =>
+            run("addEntry empty name", () =>
+              addEntry({ name: "", message: "valid message" })
+            )
+          }
+        >
+          Empty name
+        </button>
+        <button
+          disabled={pending}
+          data-testid="guestbook-bad-long-message"
+          onClick={() =>
+            run("addEntry long message", () =>
+              addEntry({ name: "Ada", message: "x".repeat(500) })
+            )
+          }
+        >
+          Message over 280 chars
+        </button>
+        <button
+          disabled={pending}
+          data-testid="guestbook-bad-negative-id"
+          onClick={() => run("deleteEntry(-1)", () => deleteEntry(-1))}
+        >
+          Delete id -1
+        </button>
+      </div>
+
+      {lastOk && (
+        <p
+          style={{ color: "green", fontSize: "0.85rem", marginTop: "0.75rem" }}
+          data-testid="guestbook-last-ok"
+        >
+          ✓ {lastOk}
+        </p>
+      )}
+      {lastError && (
+        <p
+          style={{
+            color: "crimson",
+            fontSize: "0.85rem",
+            marginTop: "0.75rem",
+          }}
+          data-testid="guestbook-last-error"
+        >
+          ✗ {lastError}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/examples/typed-file-router/src/guestbook-actions.ts
+++ b/examples/typed-file-router/src/guestbook-actions.ts
@@ -1,0 +1,75 @@
+/**
+ * Guestbook server functions — demonstrate `createFunction` from
+ * `@lazarv/react-server/function` paired with Zod schemas, parallel
+ * to the typed-router example.
+ *
+ * Two design wins to spotlight:
+ *
+ *   1. Per-arg validation runs at the protocol layer. Bad payloads
+ *      are rejected with HTTP 400 (`x-react-server-action-error`
+ *      header carries the reason) before the handler executes.
+ *   2. Handler parameter types are inferred from the Zod schemas.
+ *      Hover over `addEntry` at its call site to see
+ *      `(input: { name: string; message: string })` — derived
+ *      directly from the schema, no manual annotation.
+ *
+ * Lives in `src/` so the file-router doesn't pick it up as a route
+ * (only `pages/` is scanned). Pages import from this module by name.
+ */
+"use server";
+
+import { createFunction } from "@lazarv/react-server/function";
+import { z } from "zod";
+
+export type GuestbookEntry = {
+  id: number;
+  name: string;
+  message: string;
+  createdAt: string;
+};
+
+let entries: GuestbookEntry[] = [
+  {
+    id: 1,
+    name: "Ada",
+    message: "Hello from the typed file-router demo!",
+    createdAt: new Date(Date.now() - 1000 * 60 * 60).toISOString(),
+  },
+];
+
+/** Read all entries. Plain `"use server"` — no validation needed. */
+export async function listEntries(): Promise<GuestbookEntry[]> {
+  return entries;
+}
+
+/**
+ * Add a new entry. Handler `input` types as
+ * `{ name: string; message: string }` from the Zod schema below.
+ */
+export const addEntry = createFunction([
+  z.object({
+    name: z.string().min(1, "name required").max(60, "name too long"),
+    message: z.string().min(1, "message required").max(280, "message too long"),
+  }),
+])(async function addEntry(input) {
+  const next: GuestbookEntry = {
+    id: entries.length === 0 ? 1 : Math.max(...entries.map((e) => e.id)) + 1,
+    name: input.name,
+    message: input.message,
+    createdAt: new Date().toISOString(),
+  };
+  entries = [...entries, next];
+  return next;
+});
+
+/**
+ * Delete an entry by id. The schema coerces wire strings into a
+ * positive integer; the handler always sees a `number`.
+ */
+export const deleteEntry = createFunction([z.coerce.number().int().positive()])(
+  async function deleteEntry(id) {
+    const before = entries.length;
+    entries = entries.filter((e) => e.id !== id);
+    return { id, deleted: entries.length < before };
+  }
+);

--- a/examples/typed-router/App.tsx
+++ b/examples/typed-router/App.tsx
@@ -75,6 +75,9 @@ export default function App() {
               <router.todos.Link style={{ color: "blue" }}>
                 Todos
               </router.todos.Link>
+              <router.guestbook.Link style={{ color: "blue" }}>
+                Guestbook
+              </router.guestbook.Link>
               <router.products.Link style={{ color: "blue" }}>
                 Products
               </router.products.Link>

--- a/examples/typed-router/DeleteEntryButton.tsx
+++ b/examples/typed-router/DeleteEntryButton.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useTransition } from "react";
+import { useClient } from "@lazarv/react-server/client";
+import { deleteEntry } from "./guestbook-actions";
+
+/**
+ * Tiny client island for the per-entry delete button.
+ *
+ * Each entry rendered by the server component (`Guestbook.tsx`) gets
+ * one of these next to it. The `id` arrives via props from the server
+ * — typed end-to-end as `number`, narrowed by Zod's
+ * `.coerce.number().int().positive()` at the action boundary.
+ *
+ * After a successful delete, the runtime's `refresh()` re-runs the
+ * parent server component so the list reflects the change.
+ */
+export default function DeleteEntryButton({ id }: { id: number }) {
+  const { refresh } = useClient();
+  const [pending, startTransition] = useTransition();
+
+  return (
+    <button
+      type="button"
+      disabled={pending}
+      data-testid={`guestbook-delete-${id}`}
+      onClick={() =>
+        startTransition(async () => {
+          // `deleteEntry(id)` — `id: number` inferred from the schema.
+          await deleteEntry(id);
+          await refresh();
+        })
+      }
+      style={{
+        marginLeft: "0.5rem",
+        padding: "0.1rem 0.5rem",
+        fontSize: "0.75rem",
+        color: "crimson",
+        background: "transparent",
+        border: "1px solid currentColor",
+        borderRadius: 3,
+        cursor: pending ? "wait" : "pointer",
+      }}
+    >
+      {pending ? "…" : "delete"}
+    </button>
+  );
+}

--- a/examples/typed-router/Guestbook.tsx
+++ b/examples/typed-router/Guestbook.tsx
@@ -1,0 +1,68 @@
+/**
+ * Guestbook page — server component reading the entries list, with a
+ * client island below the list driving the `createFunction` actions.
+ *
+ * The split lets the demo show both halves of the typed surface:
+ *
+ *   - Server side (this file): reads the list directly, no resource /
+ *     client cache layer in the way.
+ *   - Client island (`./GuestbookForm.tsx`): calls `addEntry` /
+ *     `deleteEntry` with arguments inferred from the Zod schemas —
+ *     the call site is type-safe.
+ *
+ * On RSC navigation back to this page after a mutation, the server
+ * re-runs and the new entries show up. No invalidate hooks needed
+ * because there's no client-side cache.
+ */
+import { listEntries } from "./guestbook-actions";
+import DeleteEntryButton from "./DeleteEntryButton";
+import GuestbookForm from "./GuestbookForm";
+
+export default async function Guestbook() {
+  const entries = await listEntries();
+
+  return (
+    <div>
+      <h2>Guestbook</h2>
+      <p>
+        Server functions wrapped with{" "}
+        <code>createFunction([zod-schema])(handler)</code>. Validation runs at
+        the protocol layer — try opening DevTools and submitting an empty
+        message; the request returns HTTP 400 with{" "}
+        <code>x-react-server-action-error: validate_failed</code> and the
+        handler never runs.
+      </p>
+
+      <ul style={{ listStyle: "none", padding: 0 }}>
+        {entries.length === 0 && (
+          <li style={{ color: "gray" }}>(no entries yet)</li>
+        )}
+        {entries.map((entry) => (
+          <li
+            key={entry.id}
+            data-testid={`guestbook-entry-${entry.id}`}
+            style={{
+              padding: "0.5rem 0.75rem",
+              border: "1px solid #eee",
+              borderRadius: 4,
+              marginBottom: "0.5rem",
+            }}
+          >
+            <div style={{ display: "flex", justifyContent: "space-between" }}>
+              <div>
+                <strong>{entry.name}</strong>
+                <DeleteEntryButton id={entry.id} />
+              </div>
+              <span style={{ color: "gray", fontSize: "0.8rem" }}>
+                {new Date(entry.createdAt).toLocaleString()}
+              </span>
+            </div>
+            <div style={{ marginTop: "0.25rem" }}>{entry.message}</div>
+          </li>
+        ))}
+      </ul>
+
+      <GuestbookForm />
+    </div>
+  );
+}

--- a/examples/typed-router/GuestbookForm.tsx
+++ b/examples/typed-router/GuestbookForm.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useClient } from "@lazarv/react-server/client";
+// Hover over each in your editor:
+//
+//   addEntry:    (input: { name: string; message: string }) => Promise<GuestbookEntry>
+//   deleteEntry: (id: number) => Promise<{ id: number; deleted: boolean }>
+//
+// Both signatures are inferred from the Zod schemas in
+// `guestbook-actions.ts` via the `InferArgs` machinery.
+import { addEntry, deleteEntry } from "./guestbook-actions";
+
+/**
+ * Client island that drives the createFunction-wrapped actions.
+ *
+ * Three sections:
+ *
+ *   1. The add form — a normal happy-path submission.
+ *   2. The "try a bad payload" panel — three buttons that build inputs
+ *      passing TypeScript's check but failing the Zod schema at the
+ *      protocol layer. The runtime rejects with HTTP 400 and the
+ *      handler never runs; the rejection surfaces as a thrown error
+ *      that the catch block displays to make the rejection visible.
+ *
+ * After every successful mutation we call `refresh()` from
+ * `useClient()` so the parent server component re-renders and the
+ * updated list flows back via RSC.
+ */
+export default function GuestbookForm() {
+  const { refresh } = useClient();
+  const [pending, startTransition] = useTransition();
+  const [lastError, setLastError] = useState<string | null>(null);
+  const [lastOk, setLastOk] = useState<string | null>(null);
+
+  // Shared runner — captures the success / error path once so the
+  // bad-payload buttons below stay terse.
+  const run = (label: string, fn: () => Promise<unknown>, after?: () => void) =>
+    startTransition(async () => {
+      setLastError(null);
+      setLastOk(null);
+      try {
+        await fn();
+        setLastOk(`${label} succeeded`);
+        after?.();
+      } catch (err) {
+        setLastError(
+          `${label} → ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    });
+
+  return (
+    <section
+      style={{
+        marginTop: "2rem",
+        padding: "1rem",
+        border: "1px solid #ddd",
+        borderRadius: 6,
+      }}
+    >
+      <h3 style={{ marginTop: 0 }}>Add an entry</h3>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          // Capture synchronously — React nullifies `e.currentTarget`
+          // before the async transition body runs.
+          const form = e.currentTarget;
+          const fd = new FormData(form);
+          const name = String(fd.get("name") ?? "");
+          const message = String(fd.get("message") ?? "");
+          run(
+            "addEntry (form)",
+            () => addEntry({ name, message }),
+            () => {
+              form.reset();
+              return refresh();
+            }
+          );
+        }}
+        style={{ display: "grid", gap: "0.5rem", maxWidth: 480 }}
+      >
+        <input
+          name="name"
+          placeholder="Your name"
+          data-testid="guestbook-name"
+          required
+          style={{ padding: "0.4rem" }}
+        />
+        <textarea
+          name="message"
+          placeholder="Leave a message"
+          data-testid="guestbook-message"
+          required
+          rows={3}
+          style={{ padding: "0.4rem", fontFamily: "inherit" }}
+        />
+        <button
+          type="submit"
+          disabled={pending}
+          data-testid="guestbook-submit"
+          style={{ padding: "0.4rem 0.75rem", justifySelf: "start" }}
+        >
+          {pending ? "Saving…" : "Add entry"}
+        </button>
+      </form>
+
+      <h3 style={{ marginTop: "2rem" }}>Try a bad payload</h3>
+      <p style={{ fontSize: "0.85rem", color: "gray", marginTop: 0 }}>
+        Each button below builds an input that{" "}
+        <strong>passes TypeScript</strong> (the shape is valid) but{" "}
+        <strong>fails the Zod schema at the protocol layer</strong>. Watch the
+        Network tab in DevTools — every rejection is <code>HTTP 400</code> with{" "}
+        <code>x-react-server-action-error: validate_failed</code>, and the
+        handler never executes.
+      </p>
+
+      <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
+        <button
+          disabled={pending}
+          data-testid="guestbook-bad-empty-name"
+          // Empty `name` — fails `z.string().min(1, "name required")`.
+          onClick={() =>
+            run("addEntry empty name", () =>
+              addEntry({ name: "", message: "valid message" })
+            )
+          }
+        >
+          Empty name
+        </button>
+        <button
+          disabled={pending}
+          data-testid="guestbook-bad-long-message"
+          // 500-char message — fails `z.string().max(280, "message too long")`.
+          onClick={() =>
+            run("addEntry long message", () =>
+              addEntry({ name: "Ada", message: "x".repeat(500) })
+            )
+          }
+        >
+          Message over 280 chars
+        </button>
+        <button
+          disabled={pending}
+          data-testid="guestbook-bad-negative-id"
+          // Negative id — fails `z.coerce.number().int().positive()`.
+          onClick={() => run("deleteEntry(-1)", () => deleteEntry(-1))}
+        >
+          Delete id -1
+        </button>
+      </div>
+
+      {lastOk && (
+        <p
+          style={{ color: "green", fontSize: "0.85rem", marginTop: "0.75rem" }}
+          data-testid="guestbook-last-ok"
+        >
+          ✓ {lastOk}
+        </p>
+      )}
+      {lastError && (
+        <p
+          style={{
+            color: "crimson",
+            fontSize: "0.85rem",
+            marginTop: "0.75rem",
+          }}
+          data-testid="guestbook-last-error"
+        >
+          ✗ {lastError}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/examples/typed-router/guestbook-actions.ts
+++ b/examples/typed-router/guestbook-actions.ts
@@ -1,0 +1,88 @@
+/**
+ * Guestbook server functions — demonstrate `createFunction` from
+ * `@lazarv/react-server/function` paired with Zod schemas.
+ *
+ * Two design wins to spotlight:
+ *
+ *   1. Per-arg validation runs at the protocol layer. If the client
+ *      sends a payload that doesn't match the schema, the request is
+ *      rejected with HTTP 400 *before* the handler executes. The
+ *      response header `x-react-server-action-error` carries the
+ *      reason code (`validate_failed`, `wire_shape_mismatch`, …).
+ *   2. Handler parameters are inferred from the Zod schemas. Open
+ *      `addEntry` in a TS-aware editor and hover over `input` — it's
+ *      `{ name: string; message: string }`, derived directly from the
+ *      schema. A misuse like `addEntry({ wrong: "shape" })` at the
+ *      call site is a TypeScript error, not a runtime surprise.
+ *
+ * No client-side caching layer here — this page intentionally avoids
+ * the resource/loader pattern so the action mutations are observable
+ * directly on subsequent reads. Module-level state resets on dev
+ * restart, which is what you want for a demo.
+ */
+"use server";
+
+import { createFunction } from "@lazarv/react-server/function";
+import { z } from "zod";
+
+export type GuestbookEntry = {
+  id: number;
+  name: string;
+  message: string;
+  createdAt: string;
+};
+
+let entries: GuestbookEntry[] = [
+  {
+    id: 1,
+    name: "Ada",
+    message: "Hello from the typed router demo!",
+    createdAt: new Date(Date.now() - 1000 * 60 * 60).toISOString(),
+  },
+];
+
+/**
+ * Read all entries. Plain `"use server"` export — no validation needed
+ * for read-only no-arg calls (and no `createFunction` wrapper, so the
+ * dev-strict warning kindly reminds you about that).
+ */
+export async function listEntries(): Promise<GuestbookEntry[]> {
+  return entries;
+}
+
+/**
+ * Add a new entry. Schema-validated:
+ *   - `name`: 1–60 chars
+ *   - `message`: 1–280 chars
+ *
+ * Handler `input` types as `{ name: string; message: string }` — try
+ * hovering over it.
+ */
+export const addEntry = createFunction([
+  z.object({
+    name: z.string().min(1, "name required").max(60, "name too long"),
+    message: z.string().min(1, "message required").max(280, "message too long"),
+  }),
+])(async function addEntry(input) {
+  const next: GuestbookEntry = {
+    id: entries.length === 0 ? 1 : Math.max(...entries.map((e) => e.id)) + 1,
+    name: input.name,
+    message: input.message,
+    createdAt: new Date().toISOString(),
+  };
+  entries = [...entries, next];
+  return next;
+});
+
+/**
+ * Delete an entry by id. The schema coerces wire strings (e.g. from a
+ * `<form>` field) into a positive integer; the handler always sees a
+ * `number`.
+ */
+export const deleteEntry = createFunction([z.coerce.number().int().positive()])(
+  async function deleteEntry(id) {
+    const before = entries.length;
+    entries = entries.filter((e) => e.id !== id);
+    return { id, deleted: entries.length < before };
+  }
+);

--- a/examples/typed-router/router.tsx
+++ b/examples/typed-router/router.tsx
@@ -22,6 +22,7 @@ import PostPage from "./PostPage";
 import ProductList from "./ProductList";
 import TodosPage from "./TodosPage";
 import TodosLoading from "./TodosLoading";
+import Guestbook from "./Guestbook";
 import NotFound from "./NotFound";
 import UserNotFound from "./UserNotFound";
 
@@ -41,6 +42,8 @@ const router = createRouter({
     loading: TodosLoading,
     resources: [todosServerMapping, todosClientMapping],
   }),
+  // Server-function demo: `createFunction` actions with Zod-typed args.
+  guestbook: createRoute(routes.guestbook, <Guestbook />),
   userNotFound: createRoute(routes.userNotFound, <UserNotFound />),
   notFound: createRoute(routes.notFound, <NotFound />),
 });

--- a/examples/typed-router/routes.ts
+++ b/examples/typed-router/routes.ts
@@ -13,6 +13,11 @@ export const home = createRoute("/", { exact: true });
 
 export const about = createRoute("/about", { exact: true });
 
+// Server-function demo. No params / search; the page reads the entries
+// list directly from a server-side store and a client island form
+// drives `createFunction`-wrapped mutations.
+export const guestbook = createRoute("/guestbook", { exact: true });
+
 // Zod `validate` — full schema-based validation with defaults and coercion.
 export const user = createRoute("/user/[id]", {
   exact: true,

--- a/packages/react-server/config/validate.mjs
+++ b/packages/react-server/config/validate.mjs
@@ -499,6 +499,13 @@ const REACT_SERVER_SCHEMA = {
       secretFile: optional(is.string),
       previousSecrets: optional(arrayOf(is.string)),
       previousSecretFiles: optional(arrayOf(is.string)),
+      // Dev-only: warn on the server when a Server Function is invoked
+      // without a `createFunction` validation contract. Defaults to `true`.
+      // Set to `false` to silence the warning (e.g. while migrating an
+      // existing codebase incrementally). Has no effect in production —
+      // the warning is purely a dev-time guardrail and never logs in
+      // built/started servers.
+      strict: optional(is.boolean),
       limits: optional(
         objectShape({
           maxRows: optional(
@@ -752,6 +759,7 @@ const EXAMPLES = {
   "serverFunctions.secretFile": `serverFunctions: { secretFile: "./secret.pem" }`,
   "serverFunctions.previousSecrets": `serverFunctions: { previousSecrets: ["old-secret"] }`,
   "serverFunctions.previousSecretFiles": `serverFunctions: { previousSecretFiles: ["./old.pem"] }`,
+  "serverFunctions.strict": `serverFunctions: { strict: false }  // dev-only: silence the "no createFunction" warning`,
   "serverFunctions.limits": `serverFunctions: { limits: { maxBytes: 4 * 1024 * 1024 } }`,
   "serverFunctions.limits.maxRows": `serverFunctions: { limits: { maxRows: 10000 } }`,
   "serverFunctions.limits.maxDepth": `serverFunctions: { limits: { maxDepth: 64 } }`,

--- a/packages/react-server/lib/plugins/use-server.mjs
+++ b/packages/react-server/lib/plugins/use-server.mjs
@@ -269,6 +269,21 @@ export default function useServer(type, manifest) {
           ];
         } else {
           for (const name of exports) {
+            // 4th arg: read `createFunction`-attached meta off the
+            // exported function via the registry symbol. When the export
+            // was wrapped by `createFunction(spec)(handler)`, the
+            // wrapper attached the normalized meta object at
+            // `Symbol.for("@lazarv/react-server/function/meta")` (see
+            // `packages/react-server/server/function.mjs`). Bare
+            // `"use server"` exports leave this slot `undefined`, and
+            // `registerServerReference` skips the meta-registry write —
+            // so back-compat is fully preserved without any AST walk-up.
+            //
+            // We use `Symbol.for(...)` inline rather than importing a
+            // module-level constant so the codegen stays a single,
+            // self-contained statement and doesn't introduce a new
+            // import edge into the dependency graph for every
+            // `"use server"` module.
             ast.body.push({
               type: "ExpressionStatement",
               expression: {
@@ -289,6 +304,35 @@ export default function useServer(type, manifest) {
                   {
                     type: "Literal",
                     value: name,
+                  },
+                  {
+                    type: "MemberExpression",
+                    object: {
+                      type: "Identifier",
+                      name: name,
+                    },
+                    computed: true,
+                    property: {
+                      type: "CallExpression",
+                      callee: {
+                        type: "MemberExpression",
+                        object: {
+                          type: "Identifier",
+                          name: "Symbol",
+                        },
+                        property: {
+                          type: "Identifier",
+                          name: "for",
+                        },
+                        computed: false,
+                      },
+                      arguments: [
+                        {
+                          type: "Literal",
+                          value: "@lazarv/react-server/function/meta",
+                        },
+                      ],
+                    },
                   },
                 ],
               },

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -43,6 +43,10 @@
       "types": "./lib/http/index.d.ts",
       "default": "./lib/http/index.mjs"
     },
+    "./function": {
+      "types": "./server/function.d.ts",
+      "default": "./server/function.mjs"
+    },
     "./live": {
       "types": "./server/live.d.ts",
       "default": "./server/live.jsx"

--- a/packages/react-server/server/action-register.mjs
+++ b/packages/react-server/server/action-register.mjs
@@ -92,12 +92,18 @@ function createServerRefBind(fullId) {
  * current $$id — if they differ (e.g. due to a fresh random IV on each
  * read), useActionState cannot match the form state back to the component.
  */
-export function registerServerReference(fn, id, name) {
+export function registerServerReference(fn, id, name, meta) {
   const fullId = `${id}#${name}`;
 
   // Register in @lazarv/rsc's internal serverReferenceRegistry so that
-  // decodeAction / lookupServerReference can find it.
-  _registerServerReference(fn, id, name);
+  // decodeAction / lookupServerReference can find it. When `meta` is
+  // supplied (the bundler-driven `createFunction` path), it's also
+  // recorded in the server-function metadata registry so the
+  // protocol-level decoder can drive per-slot parse/validate during the
+  // args walk. Bare `"use server"` actions (no `createFunction`) pass
+  // `meta = undefined` and take the unvalidated legacy walk — back-compat
+  // is preserved.
+  _registerServerReference(fn, id, name, meta);
 
   // Set server reference metadata directly on the original fn, because
   // the generated code uses fn by reference (the return value is ignored).

--- a/packages/react-server/server/function.d.ts
+++ b/packages/react-server/server/function.d.ts
@@ -1,0 +1,568 @@
+/**
+ * Server Functions: per-arg validation API.
+ *
+ * `createFunction` pairs a `"use server"` action with a per-slot
+ * parse/validate spec. The bundler walks up from the call site and
+ * forwards the spec to `registerServerReference`, so the protocol-level
+ * decoder can apply parse → validate slot-by-slot during the args walk
+ * and abort the request on the first failure — before any handler code
+ * runs.
+ *
+ * Bound captures (closure values) are NOT part of this contract;
+ * they're integrity-protected by the AEAD action token.
+ */
+
+import type { ValidateSchema, InferSchema } from "./router";
+
+// ── Wire-aware spec types ─────────────────────────────────────────────────
+
+/**
+ * Wire-aware FormData argument constraint. Drives `decodeFormDataSlot`
+ * directly: declared entries are looked up by exact key, anything else
+ * is rejected / dropped / allowed per the `unknown` policy.
+ *
+ * The `E` type parameter records the entries map at the type level, so
+ * `InferArg<FormDataSpec<E>>` can produce a `TypedFormData<E>` whose
+ * `get`/`getAll`/`has` methods are typed by entry name.
+ */
+export interface FormDataSpec<
+  E extends Record<string, unknown> = Record<string, unknown>,
+> {
+  readonly _kind: "formdata";
+  readonly entries: E;
+  readonly unknown: "reject" | "drop" | "allow";
+}
+
+/**
+ * Wire-aware File entry constraint inside a `formData(...)`. Size and
+ * MIME are checked synchronously against `Blob.size` / `Blob.type`
+ * before the entry is added to the result.
+ *
+ * `M` records the MIME allowlist as a tuple of string literals (e.g.
+ * `readonly ["image/png", "image/jpeg"]`), so the inferred runtime
+ * `File` value can have a narrowed `type` property — see
+ * `TypedFile<M>` below.
+ *
+ * `O` records the `optional` flag so the inferred value type can
+ * include `| undefined` when the entry is declared optional.
+ */
+export interface FileSpec<
+  M extends readonly string[] = readonly string[],
+  O extends boolean = boolean,
+> {
+  readonly _kind: "file";
+  readonly maxBytes?: number;
+  readonly mime?: M;
+  readonly validate?: (value: File | Blob) => boolean;
+  readonly optional?: O;
+}
+
+/**
+ * Wire-aware Blob entry constraint. Same wire-shape semantics as
+ * `FileSpec`; kept separate for naming clarity in declarations and so
+ * the inferred runtime value type is `Blob` rather than `File`.
+ */
+export interface BlobSpec<
+  M extends readonly string[] = readonly string[],
+  O extends boolean = boolean,
+> {
+  readonly _kind: "blob";
+  readonly maxBytes?: number;
+  readonly mime?: M;
+  readonly validate?: (value: File | Blob) => boolean;
+  readonly optional?: O;
+}
+
+// ── MIME-narrowed File / Blob ─────────────────────────────────────────────
+
+/**
+ * `File` whose `type` is narrowed to the declared MIME allowlist.
+ * Structurally a subtype of `File`, so it interops cleanly with any API
+ * that takes a `File` — but lets you `switch (f.type) { case "image/png": … }`
+ * with full autocomplete and exhaustiveness.
+ */
+export type TypedFile<M extends string = string> = Omit<File, "type"> & {
+  readonly type: M;
+};
+
+/**
+ * `Blob` whose `type` is narrowed to the declared MIME allowlist. Same
+ * shape as `TypedFile<M>`, just for `Blob`.
+ */
+export type TypedBlob<M extends string = string> = Omit<Blob, "type"> & {
+  readonly type: M;
+};
+
+// ── Entry-value inference (FormData entries) ──────────────────────────────
+
+/** Narrow `File`/`Blob` by the spec's MIME allowlist when present. */
+type _FileFromSpec<S> =
+  S extends FileSpec<infer M, any>
+    ? M extends readonly string[]
+      ? // `readonly string[]` (the default, no mime declared) matches but
+        // `M[number]` collapses to `string` — same as `File["type"]`, so
+        // the narrowed and unnarrowed branches converge.
+        TypedFile<M[number]>
+      : File
+    : File;
+
+type _BlobFromSpec<S> =
+  S extends BlobSpec<infer M, any>
+    ? M extends readonly string[]
+      ? TypedBlob<M[number]>
+      : Blob
+    : Blob;
+
+type _MaybeOptional<T, S> = S extends { optional: true } ? T | undefined : T;
+
+/**
+ * Infer the runtime value type for one declared FormData entry. Wire-
+ * aware specs (file / blob) become typed File / Blob; Standard Schemas
+ * flow through `InferSchema`; anything else falls back to
+ * `FormDataEntryValue` (the platform default).
+ */
+export type InferEntryValue<E> =
+  E extends FileSpec<any, any>
+    ? _MaybeOptional<_FileFromSpec<E>, E>
+    : E extends BlobSpec<any, any>
+      ? _MaybeOptional<_BlobFromSpec<E>, E>
+      : E extends ValidateSchema<any>
+        ? InferSchema<E>
+        : FormDataEntryValue;
+
+// ── Typed FormData ────────────────────────────────────────────────────────
+
+/**
+ * `FormData` whose `get` / `getAll` / `has` methods are typed by entry
+ * name. The decoder produces a real `FormData` populated only with the
+ * declared entries (under `unknown: "reject" | "drop"`), so by the time
+ * the handler reads it, every declared entry is either present with
+ * the validated value or — for `optional: true` file/blob entries —
+ * legitimately absent. We therefore type `get(<declared key>)` as
+ * non-null: optional entries carry the `| undefined` in their value
+ * type itself, so the user never has to null-check a key the schema
+ * declared as required.
+ *
+ * Methods called with arbitrary string keys fall through to the
+ * platform `FormData` overload, returning `FormDataEntryValue | null`
+ * as usual.
+ */
+export interface TypedFormData<
+  E extends Record<string, unknown>,
+> extends FormData {
+  get<K extends keyof E & string>(name: K): InferEntryValue<E[K]>;
+  get(name: string): FormDataEntryValue | null;
+
+  getAll<K extends keyof E & string>(name: K): Array<InferEntryValue<E[K]>>;
+  getAll(name: string): FormDataEntryValue[];
+
+  has<K extends keyof E & string>(name: K): boolean;
+  has(name: string): boolean;
+}
+
+// ── Wire-aware spec types for the rest of the Flight protocol ────────────
+
+/**
+ * Union of constructor references the Flight protocol can carry as
+ * `$AT` payloads. Users pass these by reference (e.g. `Uint8Array`),
+ * not by string name — the runtime check is `instanceof Ctor`, and TS
+ * can derive the instance type via `InstanceType<C>`.
+ */
+export type ArrayBufferViewCtor =
+  | typeof Int8Array
+  | typeof Uint8Array
+  | typeof Uint8ClampedArray
+  | typeof Int16Array
+  | typeof Uint16Array
+  | typeof Int32Array
+  | typeof Uint32Array
+  | typeof Float32Array
+  | typeof Float64Array
+  | typeof BigInt64Array
+  | typeof BigUint64Array
+  | typeof DataView;
+
+/**
+ * Extract the instance type from any constructor reference. Falls
+ * through to `ArrayBufferView` for unknown shapes (rather than `never`,
+ * which would poison handler-parameter inference).
+ */
+type _CtorInstance<C> = C extends abstract new (...args: any) => infer I
+  ? I
+  : ArrayBufferView;
+
+export interface ArrayBufferSpec {
+  readonly _kind: "arrayBuffer";
+  readonly maxBytes?: number;
+}
+
+export interface TypedArraySpec<
+  C extends ArrayBufferViewCtor | ReadonlyArray<ArrayBufferViewCtor> =
+    ReadonlyArray<ArrayBufferViewCtor>,
+> {
+  readonly _kind: "typedArray";
+  readonly ctor?: C;
+  readonly maxBytes?: number;
+}
+
+export interface MapSpec<K = unknown, V = unknown> {
+  readonly _kind: "map";
+  readonly maxSize?: number;
+  readonly key?: K;
+  readonly value?: V;
+}
+
+export interface SetSpec<V = unknown> {
+  readonly _kind: "set";
+  readonly maxSize?: number;
+  readonly value?: V;
+}
+
+export interface StreamSpec {
+  readonly _kind: "stream";
+  readonly maxChunks?: number;
+  readonly maxBytes?: number;
+}
+
+export interface AsyncIterableSpec<V = unknown> {
+  readonly _kind: "asyncIterable";
+  readonly maxYields?: number;
+  readonly value?: V;
+}
+
+export interface IterableSpec<V = unknown> {
+  readonly _kind: "iterable";
+  readonly maxYields?: number;
+  readonly value?: V;
+}
+
+export interface PromiseSpec<V = unknown> {
+  readonly _kind: "promise";
+  readonly value?: V;
+}
+
+// Helpers to extract the inner schema's inferred type, falling back to
+// `unknown` when no schema was declared.
+type _InferInner<V> = V extends ValidateSchema<any> ? InferSchema<V> : unknown;
+
+// ── Top-level arg inference ───────────────────────────────────────────────
+
+/**
+ * Infer the runtime type for a single arg slot. Wire-aware specs map to
+ * platform types (`TypedFormData<E>`, `TypedFile<M>`, `TypedBlob<M>`,
+ * `ReadableStream`, `Map`, `Set`, …); Standard Schemas (Zod / Valibot /
+ * ArkType / …) flow through `InferSchema`. Anything else (e.g. `null` /
+ * `undefined` — declared "accept anything") becomes `unknown`, which
+ * keeps the call site honest about the missing validation.
+ */
+export type InferArg<S> =
+  S extends FormDataSpec<infer E>
+    ? TypedFormData<E>
+    : S extends FileSpec<any, any>
+      ? _MaybeOptional<_FileFromSpec<S>, S>
+      : S extends BlobSpec<any, any>
+        ? _MaybeOptional<_BlobFromSpec<S>, S>
+        : S extends ArrayBufferSpec
+          ? ArrayBuffer
+          : S extends TypedArraySpec<infer C>
+            ? C extends ReadonlyArray<ArrayBufferViewCtor>
+              ? _CtorInstance<C[number]>
+              : C extends ArrayBufferViewCtor
+                ? _CtorInstance<C>
+                : ArrayBufferView
+            : S extends MapSpec<infer K, infer V>
+              ? Map<_InferInner<K>, _InferInner<V>>
+              : S extends SetSpec<infer V>
+                ? Set<_InferInner<V>>
+                : S extends StreamSpec
+                  ? ReadableStream
+                  : S extends AsyncIterableSpec<infer V>
+                    ? AsyncIterable<_InferInner<V>>
+                    : S extends IterableSpec<infer V>
+                      ? Iterable<_InferInner<V>>
+                      : S extends PromiseSpec<infer V>
+                        ? Promise<_InferInner<V>>
+                        : S extends ValidateSchema<any>
+                          ? InferSchema<S>
+                          : unknown;
+
+/**
+ * Map a tuple of arg specs to a tuple of inferred runtime types. Drives
+ * the handler's parameter-type inference in `createFunction`.
+ */
+export type InferArgs<TArgs extends ReadonlyArray<unknown>> = {
+  [K in keyof TArgs]: InferArg<TArgs[K]>;
+};
+
+// ── Spec shape ────────────────────────────────────────────────────────────
+
+/**
+ * Per-arg parse/validate spec — the object form passed to
+ * `createFunction({ validate, parse })`. Both fields are arrays of
+ * per-slot entries indexed by the *runtime arg slot* (what the client
+ * puts on the wire), NOT by handler signature param. Bound captures
+ * (closure values) are not subject to this validation.
+ */
+export interface CreateFunctionSpec<
+  TArgs extends ReadonlyArray<unknown> = ReadonlyArray<unknown>,
+> {
+  validate?: TArgs;
+  parse?: ReadonlyArray<((value: unknown) => unknown) | undefined>;
+}
+
+// ── Wire-aware factories ──────────────────────────────────────────────────
+
+/**
+ * Declare a server-function argument that receives a sub-FormData
+ * object. The handler receives a `TypedFormData<E>` whose `get`,
+ * `getAll`, and `has` methods are typed by entry name.
+ *
+ * `formData(shape, options?)` — the first argument is the entry-shape
+ * map (the primary input); the second is an optional config bag.
+ * Splitting them keeps the call site clean even as future per-form
+ * constraints land in `options` (e.g. `maxEntries`, `transform`).
+ *
+ * @example
+ *   const upload = createFunction([
+ *     formData({
+ *       title: z.string(),
+ *       photo: file({ mime: ["image/png"] }),
+ *     }),
+ *   ])(async function (form) {
+ *     const title = form.get("title");      // string  (from z.string())
+ *     const photo = form.get("photo");      // TypedFile<"image/png">
+ *     const wat   = form.get("attacker");   // FormDataEntryValue | null
+ *   });
+ *
+ *   // Drop unexpected fields (e.g. when the form has React-managed
+ *   // hidden fields the schema doesn't enumerate):
+ *   formData({ title: z.string() }, { unknown: "drop" });
+ */
+export function formData<const E extends Record<string, unknown>>(
+  shape: E,
+  options?: { unknown?: "reject" | "drop" | "allow" }
+): FormDataSpec<E>;
+
+/**
+ * Declare a `File` entry constraint inside a `formData(...)`. Size /
+ * MIME are checked synchronously against `Blob.size` / `Blob.type`.
+ *
+ * When `mime` is supplied as a tuple of literals (e.g.
+ * `["image/png", "image/jpeg"]`), the inferred handler-side value is
+ * `TypedFile<"image/png" | "image/jpeg">` — `f.type` is narrowed to
+ * the declared union, so `switch`/equality checks get autocomplete and
+ * exhaustiveness.
+ */
+export function file<
+  const M extends readonly string[] = readonly string[],
+  const O extends boolean = false,
+>(options?: {
+  maxBytes?: number;
+  mime?: M;
+  validate?: (value: File | Blob) => boolean;
+  optional?: O;
+}): FileSpec<M, O>;
+
+/**
+ * Declare a `Blob` entry constraint. Same wire-shape semantics as
+ * `file({...})`. When `mime` is supplied, the inferred handler-side
+ * value is `TypedBlob<"…">`.
+ */
+export function blob<
+  const M extends readonly string[] = readonly string[],
+  const O extends boolean = false,
+>(options?: {
+  maxBytes?: number;
+  mime?: M;
+  validate?: (value: File | Blob) => boolean;
+  optional?: O;
+}): BlobSpec<M, O>;
+
+// ── Wire-aware factories for the rest of the Flight protocol ─────────────
+
+/**
+ * Declare an `ArrayBuffer` argument with an optional byte-length cap.
+ * The decoder rejects oversize payloads with
+ * `DecodeValidationError(reason: "max_bytes_exceeded")` before the
+ * handler observes the buffer.
+ */
+export function arrayBuffer(options?: { maxBytes?: number }): ArrayBufferSpec;
+
+/**
+ * Declare a `TypedArray` argument. Pass the actual constructor (or
+ * array of constructors) — references narrow both the wire-shape check
+ * (via `instanceof`) and the inferred runtime type. `ctor: Float32Array`
+ * yields `(samples: Float32Array)` in the handler signature; an array
+ * yields the union (e.g. `Uint8Array | Uint8ClampedArray`).
+ */
+export function typedArray<
+  const C extends ArrayBufferViewCtor | ReadonlyArray<ArrayBufferViewCtor>,
+>(options: { ctor: C; maxBytes?: number }): TypedArraySpec<C>;
+export function typedArray(options?: { maxBytes?: number }): TypedArraySpec;
+
+/**
+ * Declare a `Map<K, V>` argument with an optional size cap and inner
+ * key / value schemas. Inner schemas use the same Standard-Schema
+ * dispatch as the rest of `createFunction` — Zod / Valibot / ArkType
+ * all work.
+ */
+export function map<
+  const K extends ValidateSchema<any> | undefined = undefined,
+  const V extends ValidateSchema<any> | undefined = undefined,
+>(options?: { maxSize?: number; key?: K; value?: V }): MapSpec<K, V>;
+
+/**
+ * Declare a `Set<T>` argument. Same shape as `map({...})` minus the
+ * key channel.
+ */
+export function set<
+  const V extends ValidateSchema<any> | undefined = undefined,
+>(options?: { maxSize?: number; value?: V }): SetSpec<V>;
+
+/**
+ * Declare a `ReadableStream` argument. `maxChunks` and `maxBytes` are
+ * enforced as the handler consumes the stream — once either ceiling is
+ * exceeded the wrapped stream errors instead of yielding more data.
+ * Covers both flavors of Flight stream (text `$r` and binary `$b`).
+ */
+export function stream(options?: {
+  maxChunks?: number;
+  maxBytes?: number;
+}): StreamSpec;
+
+/**
+ * Declare an `AsyncIterable<T>` argument. `maxYields` caps total values;
+ * `value` runs each yielded item through a Standard Schema as the
+ * handler pulls. Bound exceeded → throws inside the iteration; schema
+ * mismatch → throws inside the iteration.
+ */
+export function asyncIterable<
+  const V extends ValidateSchema<any> | undefined = undefined,
+>(options?: { maxYields?: number; value?: V }): AsyncIterableSpec<V>;
+
+/**
+ * Declare a sync `Iterable<T>` argument. Same shape as
+ * `asyncIterable({...})`; bounds enforced on each `next()` pull.
+ */
+export function iterable<
+  const V extends ValidateSchema<any> | undefined = undefined,
+>(options?: { maxYields?: number; value?: V }): IterableSpec<V>;
+
+/**
+ * Declare a `Promise<T>` argument. Pass the resolved-value schema
+ * directly — the decoder wraps the promise so the resolution flows
+ * through the schema before the handler observes it. A rejected
+ * promise propagates unchanged.
+ */
+export function promise<const V extends ValidateSchema<any>>(
+  value: V
+): PromiseSpec<V>;
+export function promise(): PromiseSpec;
+
+// ── createFunction ────────────────────────────────────────────────────────
+
+/**
+ * `createFunction(spec)(fn)` — wrap a `"use server"` action with a
+ * per-arg parse/validate spec.
+ *
+ * The wrapper's runtime is a thin pass-through; the value is in the
+ * type-level inference. The validate slots flow through `InferArgs` to
+ * constrain the handler's parameter list, so each parameter gets the
+ * inferred runtime type from its schema or wire-aware spec.
+ *
+ * Three call shapes:
+ *
+ *   - `createFunction([s0, s1])` — array shorthand (most common).
+ *   - `createFunction({ validate, parse })` — object form when you need
+ *     per-slot pre-validate parsing too.
+ *   - `createFunction()` — no spec; marks the export so the dev-strict
+ *     warning treats it as intentionally unvalidated.
+ *
+ * @example
+ *   import { createFunction, formData, file } from
+ *     "@lazarv/react-server/function";
+ *   import { z } from "zod";
+ *
+ *   // Array shorthand — most common
+ *   export const greet = createFunction([z.string(), z.number()])(
+ *     async function greet(name, age) {
+ *       // name: string, age: number — inferred from the schemas.
+ *       "use server";
+ *       return `${name}, ${age}`;
+ *     }
+ *   );
+ *
+ *   // Object form — when parse is also needed
+ *   export const setLimit = createFunction({
+ *     parse: [(v) => Number(v)],
+ *     validate: [z.number().int().min(1).max(1000)],
+ *   })(async function setLimit(limit) {
+ *     "use server";
+ *     // limit: number (parsed from string, then validated)
+ *   });
+ *
+ *   export const upload = createFunction([
+ *     formData({
+ *       title: z.string().min(1),
+ *       photo: file({ maxBytes: 5e6, mime: ["image/png", "image/jpeg"] }),
+ *     }),
+ *   ])(async function upload(form) {
+ *     "use server";
+ *     // form: TypedFormData<{ title: ZodString; photo: FileSpec<...> }>
+ *     const title = form.get("title");      // string
+ *     const photo = form.get("photo");      // TypedFile<"image/png" | "image/jpeg">
+ *     if (photo.type === "image/png") { … } // narrowed: autocomplete works
+ *   });
+ *
+ * Requires TypeScript 5.0+ for the `const` modifier on the generic
+ * parameters (the project pin is 5.6.3).
+ */
+// Array shorthand: validate slots passed directly.
+export function createFunction<const TArgs extends ReadonlyArray<unknown>>(
+  validate: TArgs
+): <Fn extends (...args: InferArgs<TArgs>) => unknown>(fn: Fn) => Fn;
+
+// Object form: explicit `validate` and/or `parse`.
+export function createFunction<const TArgs extends ReadonlyArray<unknown>>(
+  spec: CreateFunctionSpec<TArgs>
+): <Fn extends (...args: InferArgs<TArgs>) => unknown>(fn: Fn) => Fn;
+
+/**
+ * No-spec overload — wraps a handler without declaring any per-arg
+ * validation. Useful when the only goal is to attach the
+ * `createFunction` marker (e.g. to bypass the dev-strict warning while
+ * the validation contract is still being authored). At runtime this is
+ * indistinguishable from a bare `"use server"` export — bound captures
+ * stay AEAD-protected, but call args are not validated.
+ */
+export function createFunction(): <Fn extends (...args: any[]) => unknown>(
+  fn: Fn
+) => Fn;
+
+/** Metadata symbol attached to wrapped actions. */
+export const METADATA_SYMBOL: unique symbol;
+
+/**
+ * No-op slot marker for `createFunction` arrays — placeholder for slots
+ * that don't need validation or parse, with explicit intent at the call
+ * site (instead of sparse `[, , schema]` or `undefined`):
+ *
+ *   createFunction([noop, noop, z.number()])(handler);
+ *   //                                       ^ runtime arg slot 2
+ *   //   handler signature: (a: unknown, b: unknown, c: number)
+ *
+ * Typed as a plain function so it doesn't structurally match
+ * `ValidateSchema<T>`; `InferArg<typeof noop>` therefore resolves to
+ * `unknown`, and the corresponding handler parameter is `unknown` —
+ * exactly what an unvalidated slot should be.
+ */
+export const noop: (value: unknown) => unknown;
+
+// ── Re-exports for convenience ────────────────────────────────────────────
+
+/**
+ * Re-exported from `@lazarv/react-server/router` so `createFunction`
+ * users don't need to reach across module boundaries to type their
+ * specs.
+ */
+export type { ValidateSchema, InferSchema } from "./router";

--- a/packages/react-server/server/function.mjs
+++ b/packages/react-server/server/function.mjs
@@ -1,0 +1,525 @@
+/**
+ * @lazarv/react-server/function — Server Functions: validation API
+ *
+ * `createFunction` is the opt-in wrapper that pairs a `"use server"` action
+ * handler with a per-arg parse/validate spec. The bundler walks up from a
+ * direct invocation site to forward the spec to `registerServerReference`,
+ * so the protocol-level decoder can apply parse → validate slot-by-slot
+ * during the args walk and abort the request on the first failure — the
+ * "validate as soon as we have id and meta" gate, applied at the protocol
+ * layer before any handler code runs.
+ *
+ * Design intent (recap of the discussions that led here):
+ *
+ *   - The contract describes the *runtime arg slots* (what the client puts
+ *     on the wire), NOT the handler's signature params. Bound captures
+ *     (closure values from server-side `.bind()` / arrow closures) are
+ *     hidden values, integrity-protected by the AEAD action token, and
+ *     are explicitly NOT subject to slot-walk validation. Including them
+ *     in the contract would require the user to redeclare every closure
+ *     capture's shape — which contradicts the "they're not user inputs"
+ *     framing.
+ *
+ *   - Standard Schemas (Zod / Valibot / ArkType / …) describe the
+ *     *materialized value*. They run after the value tree has been
+ *     decoded, but before the handler runs. The decoder routes them
+ *     through a host-supplied `validateArg` hook so `@lazarv/rsc` stays
+ *     library-pure.
+ *
+ *   - Wire-aware helpers (`formData`, `file`, `blob`) describe the
+ *     *wire shape* and drive decode behavior directly. They check
+ *     declared FormData entries by exact key (no prefix scan), enforce
+ *     `unknown` policy (reject / drop / allow), and apply size / MIME
+ *     ceilings against `Blob.size` / `Blob.type` synchronously, before
+ *     bytes are handed to a value-level walk. This is the only way to
+ *     gate file-size limits *before* allocations the schema can't see;
+ *     a Standard Schema running post-walk would already have to
+ *     materialize the blob.
+ *
+ * Bare `"use server"` actions without `createFunction` keep working
+ * unchanged — they take the legacy unvalidated walk in `decodeReply`.
+ *
+ * @module @lazarv/react-server/function
+ */
+
+/**
+ * Wire-aware spec marker for a `formData` argument slot. The decoder
+ * recognizes `_kind: "formdata"` and switches to its declared-key
+ * dispatch in `decodeFormDataSlot` (see
+ * `@lazarv/rsc/server/reply-decoder.mjs`).
+ */
+const FORMDATA_KIND = "formdata";
+const FILE_KIND = "file";
+const BLOB_KIND = "blob";
+const ARRAY_BUFFER_KIND = "arrayBuffer";
+const TYPED_ARRAY_KIND = "typedArray";
+const MAP_KIND = "map";
+const SET_KIND = "set";
+const STREAM_KIND = "stream";
+const ASYNC_ITERABLE_KIND = "asyncIterable";
+const ITERABLE_KIND = "iterable";
+const PROMISE_KIND = "promise";
+
+/**
+ * No-op slot marker for `createFunction` arrays.
+ *
+ * Use `noop` as a placeholder when only some slots need validation /
+ * parse. Beats sparse `[, , schema]` syntax (which lints / formatters
+ * dislike) and explicit `undefined` (which reads as "I forgot
+ * something"):
+ *
+ *   createFunction([noop, noop, z.number()])(handler);
+ *
+ *   createFunction({
+ *     parse:    [noop, noop, (v) => Number(v)],
+ *     validate: [z.string(), noop, z.number()],
+ *   })(handler);
+ *
+ * Implementation: identity function. As a parse entry it transforms the
+ * value to itself; as a validate entry, the runtime's `safeValidate`
+ * dispatch finds no `safeParse` / `assert` / `parse` method on the
+ * function and falls through to its passthrough branch — same outcome
+ * as `null` / `undefined` would yield, but with explicit intent at the
+ * call site. Slots typed `noop` infer as `unknown` in the handler.
+ */
+export const noop = (v) => v;
+
+/**
+ * Declare a server-function argument that receives a sub-FormData object.
+ *
+ * `formData(shape, options?)` — the first argument is the shape of the
+ * declared entries (the primary input); the second is an optional
+ * options bag (just `unknown` for now, but reserved for future
+ * additions like a per-formData `maxEntries` cap).
+ *
+ * The decoder walks the declared shape in order, looking up each entry
+ * by exact key in the wire FormData. Anything else under the slot's
+ * prefix is either rejected (`unknown: "reject"`, the default),
+ * silently dropped (`unknown: "drop"`), or copied through unvalidated
+ * (`unknown: "allow"` — escape hatch, documented as unsafe). On any
+ * per-entry failure the decoder throws `DecodeValidationError` and
+ * aborts the slot-walk before the next entry's bytes are touched.
+ *
+ * Each shape value is one of:
+ *
+ *   - a `file({ ... })` / `blob({ ... })` constraint (wire-aware: size
+ *     and MIME checked against `Blob.size` / `Blob.type` synchronously);
+ *   - a Standard Schema (Zod / Valibot / ArkType / …) — routed through
+ *     the host's `validateArg` hook;
+ *   - `null` / `undefined` — declares the entry as accepted, no
+ *     validation.
+ *
+ * @example
+ *   import { createFunction, formData, file } from
+ *     "@lazarv/react-server/function";
+ *   import { z } from "zod";
+ *
+ *   export const upload = createFunction([
+ *     formData({
+ *       title: z.string().min(1).max(120),
+ *       image: file({
+ *         maxBytes: 5 * 1024 * 1024,
+ *         mime: ["image/png", "image/jpeg"],
+ *       }),
+ *     }),
+ *   ])(async function upload(form) {
+ *     "use server";
+ *     // form is the validated sub-FormData with only declared entries.
+ *     const title = form.get("title");
+ *     const image = form.get("image"); // File, already size/MIME-checked
+ *     // …
+ *   });
+ *
+ * @param {Record<string, unknown>} shape
+ *   Per-entry constraints, keyed by the FormData entry name (the same
+ *   name the client puts on the wire, before the slot prefix is added).
+ * @param {object} [options]
+ * @param {"reject" | "drop" | "allow"} [options.unknown="reject"]
+ *   Policy for FormData entries that aren't declared in `shape`:
+ *   - `"reject"` (default, recommended): an unknown entry fails the
+ *     decode with `DecodeValidationError(reason: "unknown_entry")`.
+ *     Defends against attacker-injected fields like `5_role=admin`.
+ *   - `"drop"`: silently skip undeclared entries. Useful when the form
+ *     includes React-managed hidden fields the schema doesn't enumerate.
+ *   - `"allow"`: copy undeclared entries through unvalidated. Escape
+ *     hatch — documented as unsafe.
+ */
+export function formData(shape, { unknown = "reject" } = {}) {
+  if (!shape || typeof shape !== "object") {
+    throw new TypeError(
+      "formData: `shape` (first arg) is required and must be an object"
+    );
+  }
+  if (unknown !== "reject" && unknown !== "drop" && unknown !== "allow") {
+    throw new TypeError(
+      'formData: `unknown` must be one of "reject" | "drop" | "allow"'
+    );
+  }
+  // Internal spec keeps the field as `entries` to stay aligned with
+  // FormData iteration vocabulary (entries(), getAll(), …) and the
+  // decoder's existing read site in @lazarv/rsc/reply-decoder.mjs.
+  // From the developer's perspective this naming is invisible — they
+  // only ever construct specs through this factory.
+  return {
+    _kind: FORMDATA_KIND,
+    entries: shape,
+    unknown,
+  };
+}
+
+/**
+ * Declare a `File` (or `Blob` with a name) entry constraint inside a
+ * `formData`. Size and MIME are checked synchronously against
+ * `Blob.size` / `Blob.type` before the entry is added to the result —
+ * the per-request `maxBytes` ceiling already bounded the multipart
+ * parser, this gates the per-entry cap and MIME allowlist.
+ *
+ * `validate` is an optional sync custom check (e.g. magic-byte
+ * detection). It receives the wire `Blob`/`File` and must return `true`
+ * to accept; any other return value (or thrown error) fails the decode
+ * with `DecodeValidationError(reason: "custom_validate_failed")`.
+ *
+ * @param {object} [options]
+ * @param {number} [options.maxBytes]
+ *   Per-entry size limit. Compared against `wireValue.size`. When
+ *   omitted, no per-entry size cap is applied (the request-level ceiling
+ *   still bounds the body).
+ * @param {string[]} [options.mime]
+ *   Allowlist of acceptable MIME types. Compared against
+ *   `wireValue.type`. When omitted or empty, MIME is not checked. Note
+ *   that `File.type` is browser-supplied and trivially spoofable —
+ *   combine with a `validate` magic-byte check for hard guarantees.
+ * @param {(value: File | Blob) => boolean} [options.validate]
+ *   Sync custom predicate. Returns `true` to accept; any other return or
+ *   thrown error rejects.
+ * @param {boolean} [options.optional=false]
+ *   When `true`, a missing entry is accepted (the result FormData omits
+ *   the entry). Default: declared = required.
+ */
+export function file({ maxBytes, mime, validate, optional = false } = {}) {
+  return {
+    _kind: FILE_KIND,
+    ...(typeof maxBytes === "number" ? { maxBytes } : null),
+    ...(Array.isArray(mime) && mime.length > 0 ? { mime: [...mime] } : null),
+    ...(typeof validate === "function" ? { validate } : null),
+    ...(optional ? { optional: true } : null),
+  };
+}
+
+/**
+ * Declare a `Blob` entry constraint. Identical wire-shape semantics to
+ * `file({...})` — kept as a separate helper because some forms send
+ * blobs under names the consumer wants to type as `Blob` (no
+ * `.name` / file-system metadata) for clarity. The decoder's check is
+ * the same: synchronous `.size` / `.type` against `maxBytes` / `mime`.
+ *
+ * @param {object} [options] - Same shape as `file({...})`.
+ */
+export function blob({ maxBytes, mime, validate, optional = false } = {}) {
+  return {
+    _kind: BLOB_KIND,
+    ...(typeof maxBytes === "number" ? { maxBytes } : null),
+    ...(Array.isArray(mime) && mime.length > 0 ? { mime: [...mime] } : null),
+    ...(typeof validate === "function" ? { validate } : null),
+    ...(optional ? { optional: true } : null),
+  };
+}
+
+// ─── Wire-aware helpers for the rest of the Flight protocol ──────────────
+//
+// Each helper covers a Flight wire tag where a Standard Schema isn't
+// enough on its own — usually because the validation needs to run
+// pre-walk (size caps), per-chunk during stream consumption, or against
+// a host-platform type whose narrow type isn't expressible at the
+// schema layer. The helpers slot into the same `_kind`-tagged dispatch
+// that `formData()` / `file()` / `blob()` use, and the decoder's
+// `decodeWireAwareSlot` switches on `_kind` to pick the right path.
+
+/**
+ * Declare an `ArrayBuffer` argument with a byte-length cap.
+ *
+ *   stream upload that arrives as raw bytes (PDF, audio, image).
+ *
+ * The decoder checks `byteLength` after materializing the buffer — and
+ * if a per-request `maxBytes` ceiling is set in
+ * `config.serverFunctions.limits`, the multipart / JSON parser already
+ * bounded the body upstream. This is the per-slot tightening.
+ */
+export function arrayBuffer({ maxBytes } = {}) {
+  return {
+    _kind: ARRAY_BUFFER_KIND,
+    ...(typeof maxBytes === "number" ? { maxBytes } : null),
+  };
+}
+
+/**
+ * Declare a `TypedArray` argument. `ctor` narrows the acceptable
+ * constructors — pass the actual constructor reference (or an array of
+ * them) from JS's `TypedArray` family. The decoder rejects any value
+ * that isn't an `instanceof` one of the listed constructors.
+ *
+ *   typedArray({ ctor: Float32Array, maxBytes: 1024 * 1024 })
+ *   typedArray({ ctor: [Uint8Array, Uint8ClampedArray] })
+ *
+ * Using references rather than string names lets TypeScript infer the
+ * handler-side type directly via `InstanceType<C>` — `ctor: Float32Array`
+ * yields `(samples: Float32Array)` in the handler signature, no manual
+ * mapping required.
+ */
+export function typedArray({ ctor, maxBytes } = {}) {
+  const allowed =
+    typeof ctor === "function"
+      ? [ctor]
+      : Array.isArray(ctor) && ctor.length > 0
+        ? [...ctor]
+        : null;
+  return {
+    _kind: TYPED_ARRAY_KIND,
+    ...(allowed ? { ctor: allowed } : null),
+    ...(typeof maxBytes === "number" ? { maxBytes } : null),
+  };
+}
+
+/**
+ * Declare a `Map<K, V>` argument with an optional size cap and inner
+ * key / value schemas. `key` and `value` route through the host's
+ * `validateArg` hook, so any Standard Schema (Zod / Valibot / ArkType)
+ * works. Inner-schema failures are reported with the key path so the
+ * operator can find the offending entry.
+ *
+ *   map({ maxSize: 100, key: z.string(), value: z.number() })
+ */
+export function map({ maxSize, key, value } = {}) {
+  return {
+    _kind: MAP_KIND,
+    ...(typeof maxSize === "number" ? { maxSize } : null),
+    ...(key != null ? { key } : null),
+    ...(value != null ? { value } : null),
+  };
+}
+
+/**
+ * Declare a `Set<T>` argument with an optional size cap and per-item
+ * schema. Same dispatch as `map({...})` for the inner validation.
+ */
+export function set({ maxSize, value } = {}) {
+  return {
+    _kind: SET_KIND,
+    ...(typeof maxSize === "number" ? { maxSize } : null),
+    ...(value != null ? { value } : null),
+  };
+}
+
+/**
+ * Declare a `ReadableStream` argument with chunk-count and total-bytes
+ * ceilings. Covers both flavors of Flight stream (`$r` text / `$b`
+ * byte) — the decoder picks the right materializer based on the wire
+ * tag. The returned stream is wrapped: when the handler reads past
+ * `maxChunks` or `maxBytes`, the stream errors with a
+ * `DecodeValidationError`-class error rather than silently delivering
+ * unbounded data.
+ *
+ *   stream({ maxBytes: 10 * 1024 * 1024, maxChunks: 4096 })
+ */
+export function stream({ maxChunks, maxBytes } = {}) {
+  return {
+    _kind: STREAM_KIND,
+    ...(typeof maxChunks === "number" ? { maxChunks } : null),
+    ...(typeof maxBytes === "number" ? { maxBytes } : null),
+  };
+}
+
+/**
+ * Declare an `AsyncIterable<T>` argument with a yield-count ceiling
+ * and optional per-yield validation. The decoder wraps the
+ * materialized iterable; per-yield validation runs as the handler
+ * pulls values, so a malicious stream is bounded both in cardinality
+ * and content shape.
+ *
+ *   asyncIterable({ maxYields: 1000, value: z.object({ id: z.string() }) })
+ */
+export function asyncIterable({ maxYields, value } = {}) {
+  return {
+    _kind: ASYNC_ITERABLE_KIND,
+    ...(typeof maxYields === "number" ? { maxYields } : null),
+    ...(value != null ? { value } : null),
+  };
+}
+
+/**
+ * Declare a sync `Iterable<T>` argument. Same shape and semantics as
+ * `asyncIterable({...})` — the decoder wraps the materialized iterator
+ * and enforces bounds on each `next()` pull.
+ */
+export function iterable({ maxYields, value } = {}) {
+  return {
+    _kind: ITERABLE_KIND,
+    ...(typeof maxYields === "number" ? { maxYields } : null),
+    ...(value != null ? { value } : null),
+  };
+}
+
+/**
+ * Declare a `Promise<T>` argument. Pass the value schema directly:
+ *
+ *   promise(z.object({ id: z.string() }))
+ *
+ * The decoder wraps the resolved promise so the value flows through
+ * the host's `validateArg` hook before it reaches the handler. A
+ * resolution that fails validation surfaces as a rejected promise
+ * inside the handler, never as the wrong-shaped value.
+ */
+export function promise(valueSchema) {
+  return {
+    _kind: PROMISE_KIND,
+    ...(valueSchema != null ? { value: valueSchema } : null),
+  };
+}
+
+/**
+ * `createFunction(spec)(fn)` — wrap a `"use server"` action with a
+ * per-arg parse/validate spec.
+ *
+ * The returned wrapper is the action you export. At runtime it forwards
+ * directly to `fn` — `createFunction` itself adds no overhead on the
+ * call path. Its purpose is at *bundle* time: the bundler walks up from
+ * the call site (`createFunction({...})(async function name(){...})`)
+ * and pairs the spec with the action's id/exportName, so when
+ * `registerServerReference(fn, id, name, meta)` is generated, `meta` is
+ * the spec object below. The decoder then drives slot-walk validation
+ * from that registry entry.
+ *
+ * The two-call shape (`createFunction(spec)(fn)`) keeps the spec
+ * separable from the handler — bundler heuristics target the OUTER
+ * call's argument as the spec, then the wrapped function as the
+ * handler. A single-call shape would force per-arg specs into the
+ * handler's signature, which doesn't compose well with `"use server"`
+ * placement (which has to be the FIRST statement in the body).
+ *
+ * Three call shapes are accepted:
+ *
+ *   - `createFunction([s0, s1])` — array shorthand for the validate
+ *     specs. The most common case; reads as "the args are these".
+ *   - `createFunction({ validate, parse })` — object form when you also
+ *     need pre-validate parsing. Both fields are arrays of per-slot
+ *     entries (no nested `args`); either may be omitted.
+ *   - `createFunction()` — no spec; marks the export as a server
+ *     function for the dev-strict warning while validation is still
+ *     being authored. Equivalent to bare `"use server"` at runtime.
+ *
+ * Per-slot entries (in either `validate` or as the array shorthand):
+ *
+ *   - a wire-aware spec (`formData(...)`, `file(...)`, `blob(...)`),
+ *   - a Standard Schema (Zod / Valibot / ArkType / …), routed through
+ *     the host's `validateArg` hook,
+ *   - `null` / `undefined` — slot accepted with no validation.
+ *
+ * Bound captures (closure values) are NOT part of this contract.
+ *
+ * @param {Array<unknown> | { validate?: Array<unknown>, parse?: Array<((value: unknown) => unknown) | undefined> }} [spec]
+ *   Either the validate-args array directly, or an object form.
+ *
+ * @returns {(fn: Function) => Function}
+ *   A wrapper that returns the original action unchanged. The
+ *   metadata-forwarding happens at the bundler level — at runtime the
+ *   wrapper is a thin pass-through.
+ */
+export function createFunction(spec) {
+  // The spec object is captured here purely so callers reading their own
+  // source see what they wrote. The bundler doesn't read it from the
+  // wrapper — it reads it from the spec literal at the call site and
+  // forwards it to `registerServerReference(fn, id, name, meta)`. At
+  // runtime this wrapper just returns the action; validation is driven
+  // by the decoder's registry lookup.
+  const meta = normalizeMeta(spec);
+
+  function wrap(fn) {
+    if (typeof fn !== "function") {
+      throw new TypeError("createFunction: expected a function");
+    }
+    // Stash meta on the function for hosts that want to assert at
+    // runtime (the bundler-driven path is the load-bearing one). Use a
+    // non-enumerable, non-writable descriptor so the action's surface
+    // stays clean to introspection and replays.
+    if (!hasOwn(fn, METADATA_SYMBOL)) {
+      Object.defineProperty(fn, METADATA_SYMBOL, {
+        value: meta,
+        enumerable: false,
+        writable: false,
+        configurable: false,
+      });
+    }
+    return fn;
+  }
+
+  // Expose meta on the outer wrapper too so static analyzers that reach
+  // it (rather than the inner call) can introspect.
+  Object.defineProperty(wrap, METADATA_SYMBOL, {
+    value: meta,
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+
+  return wrap;
+}
+
+/**
+ * Symbol used to attach normalized meta to a wrapped function. Hosts can
+ * read it via `fn[METADATA_SYMBOL]`; the bundler-driven path uses the
+ * registry instead, but the symbol is exposed for completeness.
+ */
+export const METADATA_SYMBOL = Symbol.for("@lazarv/react-server/function/meta");
+
+const hasOwn = Object.prototype.hasOwnProperty.call.bind(
+  Object.prototype.hasOwnProperty
+);
+
+/**
+ * Internal: normalize a user-supplied spec into the meta shape the
+ * decoder consumes (`{ validate?: [...], parse?: [...] }`). Accepts
+ * either the validate-array shorthand or the explicit object form.
+ * Validates structure but does NOT inspect schema objects (those are
+ * duck-typed at decode time via the host's `validateArg` hook).
+ */
+function normalizeMeta(spec) {
+  // No-spec: marker only, no validation.
+  if (spec === undefined || spec === null) return {};
+
+  // Array shorthand: `createFunction([s0, s1])` ↔ validate slots.
+  if (Array.isArray(spec)) {
+    return { validate: spec.slice() };
+  }
+
+  if (typeof spec !== "object") {
+    throw new TypeError(
+      "createFunction: spec must be an array (validate slots) or an object"
+    );
+  }
+
+  const meta = {};
+  if (spec.validate !== undefined) {
+    if (!Array.isArray(spec.validate)) {
+      throw new TypeError(
+        "createFunction: `validate` must be an array of per-slot specs"
+      );
+    }
+    meta.validate = spec.validate.slice();
+  }
+  if (spec.parse !== undefined) {
+    if (!Array.isArray(spec.parse)) {
+      throw new TypeError(
+        "createFunction: `parse` must be an array of per-slot functions (or undefined entries)"
+      );
+    }
+    for (const fn of spec.parse) {
+      if (fn !== undefined && fn !== null && typeof fn !== "function") {
+        throw new TypeError(
+          "createFunction: `parse` entries must be functions or undefined"
+        );
+      }
+    }
+    meta.parse = spec.parse.slice();
+  }
+  return meta;
+}

--- a/packages/react-server/server/render-rsc.jsx
+++ b/packages/react-server/server/render-rsc.jsx
@@ -4,8 +4,12 @@ import {
   decodeReply as _decodeReply,
   decodeAction,
   decodeFormState,
+  DecodeValidationError,
+  lookupServerFunctionMeta,
   renderToReadableStream,
 } from "@lazarv/rsc/server";
+import { safeValidate } from "../lib/safe-validate.mjs";
+import colors from "picocolors";
 import React from "react";
 
 import {
@@ -76,6 +80,95 @@ let DevToolsHost;
 
 const serverReferenceMap = wrapServerReferenceMap(_serverReferenceMap);
 
+// Dev-only guard rail: track which Server Functions we've already
+// warned about so a hot-loop call site doesn't drown the log. Reset is
+// implicit per dev process — the next dev restart reprints. We don't
+// expose this map; the dedup is a quality-of-life detail, not a
+// security boundary.
+const _strictWarnedActions = new Set();
+
+/**
+ * Pre-load the action's source module for a recovered actionId so the
+ * server-function meta registry is populated *before* `decodeReply`
+ * runs. The registry is filled by the module's top-level
+ * `registerServerReference(fn, id, name, meta)` calls — if decode runs
+ * before module load, every first invocation of an action would skip
+ * the slot-walk silently and the handler would receive unvalidated
+ * args. Loading the module synchronously here makes the validation
+ * contract reliable from the very first call.
+ *
+ * Failures (token didn't decrypt, action not in the manifest, module
+ * missing, init throws) are swallowed deliberately: the downstream
+ * dispatch already handles each case — invalid actionId → 404 via
+ * `ServerFunctionNotFoundError`, broken module → action invocation
+ * error. Throwing here would short-circuit those well-tested paths and
+ * obscure the real error.
+ */
+async function preloadActionModuleForMeta(actionId, serverReferenceMap) {
+  if (!actionId) return;
+  const ref = serverReferenceMap[actionId];
+  if (!ref) return;
+  try {
+    await requireModule(ref.id.replace(/^server-action:\/\//, "server://"));
+  } catch {
+    // Intentionally swallow — see JSDoc.
+  }
+}
+
+/**
+ * In dev mode, log a one-time warning when a Server Function is invoked
+ * without a `createFunction(...)` validation contract. The warning
+ * names the action in the same `<modulePath>#<exportName>` form the
+ * runtime uses internally (and that the registry keys on), so the
+ * developer can grep straight to the source.
+ *
+ * Suppressed when:
+ *   - Not running in dev (`import.meta.env.DEV` is false). The warning
+ *     is intentionally a dev-time guardrail; a built/started server
+ *     never logs it.
+ *   - `config.serverFunctions.strict === false` — escape hatch for
+ *     teams migrating an existing codebase incrementally.
+ *   - Meta is registered (the dev wrapped the action with
+ *     `createFunction`, even with empty args — declared intent, no
+ *     warning).
+ *   - The same action id was already warned about during this dev
+ *     process.
+ *
+ * Why this is worth warning: a `"use server"` export with no
+ * `createFunction` wrapper takes the unvalidated whole-tree walk in
+ * `decodeReply`. Anything the client puts on the wire reaches the
+ * handler unchanged — including types the handler's signature didn't
+ * anticipate. That's a per-action attack surface that's invisible from
+ * the call site, so we surface it on the server log where the developer
+ * actually looks.
+ */
+function warnIfNoMetaInDev(resolvedActionId, config, logger) {
+  if (!import.meta.env.DEV) return;
+  if (config?.serverFunctions?.strict === false) return;
+  if (!resolvedActionId) return;
+  if (_strictWarnedActions.has(resolvedActionId)) return;
+  if (lookupServerFunctionMeta(resolvedActionId)) return;
+  _strictWarnedActions.add(resolvedActionId);
+  // Use warn (not error) — the call still proceeds, we're just flagging
+  // a missing safety net. The message is structured so it's easy to
+  // grep/filter ("Server function called without validation:").
+  // Style guide (matches live-component logging):
+  //   - Source-path identifiers → gray italic (the action id, which
+  //     points at the file the developer would open).
+  //   - Import specifiers / paths-as-strings → cyan (they're string
+  //     literals that name a location).
+  //   - JavaScript code → magenta (function calls, config statements
+  //     — anything that's syntax rather than a path). Accented
+  //     differently from specifiers so the eye separates "where to
+  //     import from" from "what to write".
+  //   - Surrounding prose stays unstyled. The `[warning]` tag from the
+  //     dev logger carries severity on its own.
+  //   - Emoji terminates the line as a category marker.
+  (logger?.warn ?? console.warn)(
+    `Server function ${colors.gray(colors.italic(resolvedActionId))} called without validation — wrap the export with ${colors.magenta("createFunction({...})(handler)")} from ${colors.cyan("@lazarv/react-server/function")} (set ${colors.magenta("config.serverFunctions.strict = false")} to silence) 🛡️`
+  );
+}
+
 // Adapter: wraps the webpack-style client reference Proxy into an @lazarv/rsc
 // moduleResolver.  The Proxy is keyed by "moduleId#exportName" and returns
 // { id, chunks, name, async }.  We expose it as resolveClientReference(ref)
@@ -124,7 +217,8 @@ function decodeReply(body, _manifestOrOpts, opts) {
     typeof _manifestOrOpts === "object" &&
     !_manifestOrOpts.temporaryReferences &&
     !_manifestOrOpts.moduleLoader &&
-    !_manifestOrOpts.limits;
+    !_manifestOrOpts.limits &&
+    !_manifestOrOpts.actionId;
   const realOpts = isManifest ? opts : _manifestOrOpts;
   const config = getContext(CONFIG_CONTEXT)?.[CONFIG_ROOT];
   const configLimits = config?.serverFunctions?.limits;
@@ -134,6 +228,15 @@ function decodeReply(body, _manifestOrOpts, opts) {
   // encrypted id and prepends them at bind time.  The hook signature
   // matches the @lazarv/rsc decoder contract: returns null on decrypt
   // failure, or { actionId, bound } on success.
+  //
+  // When the caller supplies `actionId` (set by the dispatcher *after*
+  // decrypting the action token / FormData ID field), the meta-driven
+  // slot-walk kicks in: `lookupServerFunctionMeta` resolves the
+  // registered `createFunction` spec, and `validateArg` bridges Standard
+  // Schemas (Zod / Valibot / ArkType / …) via `safeValidate`. Wire-aware
+  // specs (`formData`, `file`, `blob`) bypass `validateArg` and are
+  // enforced directly by the decoder. Bare `"use server"` actions resolve
+  // to no meta and take the unvalidated walk — back-compat preserved.
   return _decodeReply(body, {
     ...realOpts,
     ...(configLimits
@@ -143,6 +246,20 @@ function decodeReply(body, _manifestOrOpts, opts) {
       const decrypted = decryptActionToken(id);
       if (!decrypted) return null;
       return { actionId: decrypted.actionId, bound: decrypted.bound };
+    },
+    resolveServerFunctionMeta(actionId) {
+      return lookupServerFunctionMeta(actionId);
+    },
+    validateArg(spec, value /*, ctx */) {
+      // safeValidate returns { success, data } | { success: false, fallback }.
+      // We don't expose the underlying error from safeValidate (it swallows
+      // it intentionally), but the structured `{ success: false }` from
+      // here is enough for the decoder to throw `DecodeValidationError`
+      // — the decoder fills in argIndex / actionId / reason itself. The
+      // host's logger sees the top-level error in the dispatch catch.
+      const result = safeValidate(spec, value, undefined);
+      if (result.success) return { success: true, data: result.data };
+      return { success: false, error: null };
     },
   });
 }
@@ -287,25 +404,108 @@ export async function render(Component, props = {}, options = {}) {
             if (options.middlewareError) {
               throw options.middlewareError;
             }
+            // Pre-resolve the actionId (and any token-recovered bound)
+            // BEFORE decodeReply. This is what unlocks the meta-driven
+            // slot-walk: the decoder can only validate per-arg if it
+            // knows which action it's decoding for, and the registry
+            // lookup is keyed on the recovered (decrypted) action id.
+            //
+            // For header-based action calls the id lives in the
+            // `react-server-action` header (encrypted). For progressive-
+            // enhancement form submissions it's encoded in a FormData
+            // field name (`$ACTION_ID_<token>`); we scan the multipart
+            // FormData once for that key. Failures to decrypt fall
+            // through to the unvalidated walk — that path is still
+            // protected by `serverReferenceMap` lookup downstream, so an
+            // attacker can't slip an unknown action through, only
+            // bypass per-arg validation when the token itself is
+            // tampered (which we'd reject at action-load time anyway).
+            //
+            // Once the actionId is recovered we MUST pre-load the
+            // action's module before calling decodeReply. Reason: the
+            // module's top-level `registerServerReference(fn, id, name,
+            // meta)` calls are what populate the server-function meta
+            // registry. If decodeReply runs first, `lookupServerFunctionMeta`
+            // returns undefined and the slot-walk silently falls through
+            // to the unvalidated path — every "first call" to an action
+            // skips validation. The fix is structural: load the module
+            // first, decode second.
+            let preResolvedActionId = null;
             if (isFormData) {
               const multipartFormData = await context.request.formData();
               const formData = new FormData();
               for (const [key, value] of multipartFormData.entries()) {
                 formData.append(key.replace(/^remote:\/\//, ""), value);
               }
+              if (serverActionHeader && serverActionHeader !== "null") {
+                const dec = decryptActionToken(serverActionHeader);
+                preResolvedActionId = dec ? dec.actionId : serverActionHeader;
+              } else {
+                for (const key of formData.keys()) {
+                  if (key.startsWith("$ACTION_ID_")) {
+                    const formActionId = key.slice(11);
+                    const dec = decryptActionToken(formActionId);
+                    preResolvedActionId = dec ? dec.actionId : formActionId;
+                    break;
+                  }
+                }
+              }
+              await preloadActionModuleForMeta(
+                preResolvedActionId,
+                serverReferenceMap
+              );
               try {
-                input = await decodeReply(formData, serverReferenceMap);
-              } catch {
+                input = await decodeReply(formData, serverReferenceMap, {
+                  actionId: preResolvedActionId,
+                });
+              } catch (err) {
+                // `DecodeValidationError` is the protocol-level rejection
+                // path — propagate so the outer catch maps it to a 400
+                // response. Other parse-level decode errors fall back to
+                // raw FormData (legacy behaviour for shape-mismatched but
+                // non-validated payloads).
+                if (err instanceof DecodeValidationError) throw err;
                 input = formData;
               }
             } else {
+              if (serverActionHeader && serverActionHeader !== "null") {
+                const dec = decryptActionToken(serverActionHeader);
+                preResolvedActionId = dec ? dec.actionId : serverActionHeader;
+              }
+              await preloadActionModuleForMeta(
+                preResolvedActionId,
+                serverReferenceMap
+              );
               input = await decodeReply(
                 await context.request.text(),
-                serverReferenceMap
+                serverReferenceMap,
+                { actionId: preResolvedActionId }
               );
             }
           } catch (error) {
-            logger?.error(error);
+            // Protocol-level validation failure (`createFunction` spec
+            // rejected an arg slot during decode): map to a 400. The
+            // handler never runs, the args list is never bound, and the
+            // client gets a structural rejection rather than the
+            // generic "rendered with error" path. We log the original
+            // error for the operator but keep the client-facing error
+            // payload terse — the underlying schema diagnostics can leak
+            // expected-shape details that aid attackers.
+            if (error instanceof DecodeValidationError) {
+              logger?.warn?.(
+                "Server function arg validation rejected: " +
+                  `action=${error.actionId ?? "?"} slot=${error.argIndex} ` +
+                  `reason=${error.reason}`,
+                error.original
+              );
+              const httpHeaders = getContext(HTTP_HEADERS);
+              if (httpHeaders) {
+                httpHeaders.set("x-react-server-action-error", error.reason);
+              }
+              context$(HTTP_STATUS, { status: 400 });
+            } else {
+              logger?.error(error);
+            }
             action = async () => {
               return {
                 data: null,
@@ -364,6 +564,8 @@ export async function render(Component, props = {}, options = {}) {
               if (!serverReference) {
                 throw new ServerFunctionNotFoundError();
               }
+
+              warnIfNoMetaInDev(resolvedActionId, config, logger);
 
               action = async () => {
                 try {
@@ -426,6 +628,7 @@ export async function render(Component, props = {}, options = {}) {
                   if (!serverReference) {
                     throw new ServerFunctionNotFoundError();
                   }
+                  warnIfNoMetaInDev(resolvedActionId, config, logger);
                   resolved = true;
                   action = async () => {
                     try {

--- a/packages/rsc/__tests__/flight-validation.test.mjs
+++ b/packages/rsc/__tests__/flight-validation.test.mjs
@@ -1,0 +1,769 @@
+/**
+ * Protocol-level tests for createFunction slot-walk validation in decodeReply.
+ *
+ * Exercises the encode → decode pipeline with `lookupServerFunctionMeta`
+ * driving per-arg parse/validate. The aim is the wire-protocol contract,
+ * not the higher-level @lazarv/react-server `createFunction` ergonomics
+ * (which are tested separately, end-to-end). We assert:
+ *
+ *   - When meta is registered, the slot-walk runs and returns the
+ *     validated args; bound captures (when present) are NOT in the args
+ *     array — they're integrity-protected by the token, not by this path.
+ *   - A failing Standard Schema in `validate[i]` throws
+ *     `DecodeValidationError` with the right `argIndex` / `reason`, and
+ *     no subsequent slot is touched.
+ *   - `parse[i]` runs before `validate[i]`, and a parse throw surfaces
+ *     as `reason: "parse_failed"`.
+ *   - Wire-aware specs (`_kind: "formdata"`) drive the
+ *     `decodeFormDataSlot` path: declared entries are looked up by exact
+ *     key, and the default `unknown` policy ("reject") aborts on
+ *     injected fields. We also exercise `"drop"` explicitly.
+ *   - File / Blob entry constraints reject on `maxBytes`, `mime`, and
+ *     `validate` failures synchronously, before the decode advances.
+ *   - Bare actions (no meta) still take the legacy whole-tree walk —
+ *     back-compat is preserved.
+ */
+
+import { describe, expect, test } from "vitest";
+
+import {
+  registerServerReference,
+  lookupServerFunctionMeta,
+  DecodeValidationError,
+  decodeReply,
+} from "../server/index.mjs";
+import {
+  decodeReplyFromString,
+  decodeReplyFromFormData,
+} from "../server/reply-decoder.mjs";
+import { encodeReply } from "../client/shared.mjs";
+
+// ─── Schema bridge under test ────────────────────────────────────────────
+//
+// The decoder doesn't know Zod / Valibot / etc. — the host bridges via
+// `validateArg`. We use the simplest possible bridge: a `safeParse`
+// duck-type. Real react-server delegates to `safeValidate`, which is
+// equivalent.
+function validateArg(spec, value /* , ctx */) {
+  if (spec && typeof spec.safeParse === "function") {
+    const r = spec.safeParse(value);
+    if (r.success) return { success: true, data: r.data };
+    return { success: false, error: r.error };
+  }
+  return { success: true, data: value };
+}
+
+// Minimal Zod-style schema factory for the tests. Keeps the test file
+// self-contained — no zod dep needed. `safeParse(v) → { success, data }`
+// matches what the bridge expects.
+function schema(predicate, message = "predicate failed") {
+  return {
+    safeParse(v) {
+      if (predicate(v)) return { success: true, data: v };
+      return { success: false, error: { message } };
+    },
+  };
+}
+
+const string = () => schema((v) => typeof v === "string", "expected string");
+const number = () => schema((v) => typeof v === "number", "expected number");
+const min = (n) =>
+  schema((v) => typeof v === "string" && v.length >= n, `min ${n}`);
+
+// ─── Helper: register a fake action with meta ────────────────────────────
+
+function registerAction(id, name, meta) {
+  const fn = async (...args) => ({ id: `${id}#${name}`, args });
+  return registerServerReference(fn, id, name, meta);
+}
+
+const resolveMeta = (actionId) => lookupServerFunctionMeta(actionId);
+
+// ─── Tests ───────────────────────────────────────────────────────────────
+
+describe("decodeReplyFromString — slot-walk validation", () => {
+  test("validates each arg against its Standard Schema", async () => {
+    registerAction("test/a.mjs", "greet", {
+      validate: [string(), number()],
+    });
+    const body = JSON.stringify(["hello", 42]);
+    const out = decodeReplyFromString(body, {
+      actionId: "test/a.mjs#greet",
+      resolveServerFunctionMeta: resolveMeta,
+      validateArg,
+    });
+    expect(out).toEqual(["hello", 42]);
+  });
+
+  test("rejects with DecodeValidationError on first failing slot", async () => {
+    registerAction("test/a.mjs", "greet2", {
+      validate: [string(), min(5)],
+    });
+    const body = JSON.stringify(["ok", "hi"]); // slot 1 fails min(5)
+    expect(() =>
+      decodeReplyFromString(body, {
+        actionId: "test/a.mjs#greet2",
+        resolveServerFunctionMeta: resolveMeta,
+        validateArg,
+      })
+    ).toThrow(DecodeValidationError);
+    try {
+      decodeReplyFromString(body, {
+        actionId: "test/a.mjs#greet2",
+        resolveServerFunctionMeta: resolveMeta,
+        validateArg,
+      });
+    } catch (err) {
+      expect(err).toBeInstanceOf(DecodeValidationError);
+      expect(err.argIndex).toBe(1);
+      expect(err.reason).toBe("validate_failed");
+      expect(err.actionId).toBe("test/a.mjs#greet2");
+    }
+  });
+
+  test("parse runs before validate; parse throw → parse_failed", async () => {
+    registerAction("test/a.mjs", "greet3", {
+      parse: [
+        (_v) => {
+          throw new Error("nope");
+        },
+      ],
+      validate: [string()],
+    });
+    const body = JSON.stringify(["whatever"]);
+    try {
+      decodeReplyFromString(body, {
+        actionId: "test/a.mjs#greet3",
+        resolveServerFunctionMeta: resolveMeta,
+        validateArg,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DecodeValidationError);
+      expect(err.argIndex).toBe(0);
+      expect(err.reason).toBe("parse_failed");
+    }
+  });
+
+  test("parse output flows into validate", async () => {
+    registerAction("test/a.mjs", "greet4", {
+      parse: [(v) => Number(v)],
+      validate: [number()],
+    });
+    const body = JSON.stringify(["42"]);
+    const out = decodeReplyFromString(body, {
+      actionId: "test/a.mjs#greet4",
+      resolveServerFunctionMeta: resolveMeta,
+      validateArg,
+    });
+    expect(out).toEqual([42]);
+  });
+
+  test("bare action (no meta) takes the legacy whole-tree walk", async () => {
+    // No meta registered → resolveServerFunctionMeta returns undefined →
+    // decoder falls through to the unvalidated walk and accepts anything.
+    const body = JSON.stringify(["anything", { nested: true }]);
+    const out = decodeReplyFromString(body, {
+      actionId: "test/a.mjs#unknown_action",
+      resolveServerFunctionMeta: resolveMeta,
+      validateArg,
+    });
+    expect(out).toEqual(["anything", { nested: true }]);
+  });
+
+  test("missing actionId falls through to legacy walk", async () => {
+    registerAction("test/a.mjs", "greet5", {
+      validate: [string()],
+    });
+    // Same registered action exists, but if the host doesn't pass
+    // actionId we don't run the slot-walk. This is the back-compat path
+    // for non-server-function callers of decodeReply.
+    const body = JSON.stringify([42]); // would fail string() if walked
+    const out = decodeReplyFromString(body, {
+      // no actionId
+      resolveServerFunctionMeta: resolveMeta,
+      validateArg,
+    });
+    expect(out).toEqual([42]);
+  });
+});
+
+describe("decodeReplyFromFormData — formData slot", () => {
+  function makeFormBody(rootValue, parts) {
+    const fd = new FormData();
+    fd.append("0", JSON.stringify(rootValue));
+    for (const [k, v] of Object.entries(parts)) {
+      fd.append(k, v);
+    }
+    return fd;
+  }
+
+  test("declared entries are looked up by exact key; unknown rejected", async () => {
+    const fileSpec = { _kind: "file", maxBytes: 1024 };
+    const formSpec = {
+      _kind: "formdata",
+      entries: { title: string(), photo: fileSpec },
+    };
+    registerAction("test/u.mjs", "upload", {
+      validate: [formSpec],
+    });
+
+    const photo = new File([new Uint8Array(10)], "p.png", {
+      type: "image/png",
+    });
+    const fd = makeFormBody(["$K1"], {
+      "1_title": "hello",
+      "1_photo": photo,
+    });
+    const out = decodeReplyFromFormData(fd, {
+      actionId: "test/u.mjs#upload",
+      resolveServerFunctionMeta: resolveMeta,
+      validateArg,
+    });
+    expect(Array.isArray(out)).toBe(true);
+    expect(out[0]).toBeInstanceOf(FormData);
+    expect(out[0].get("title")).toBe("hello");
+    expect(out[0].get("photo")).toBe(photo);
+  });
+
+  test("default policy ('reject') aborts on attacker-injected entry", async () => {
+    // Spec deliberately omits `unknown` — the decoder must default to
+    // reject. This is the load-bearing security default; flipping it
+    // unnoticed would silently weaken every formData() consumer.
+    const formSpec = {
+      _kind: "formdata",
+      entries: { title: string() },
+    };
+    registerAction("test/u.mjs", "upload2", {
+      validate: [formSpec],
+    });
+
+    const fd = makeFormBody(["$K1"], {
+      "1_title": "ok",
+      "1_role": "admin", // attacker injection
+    });
+    try {
+      decodeReplyFromFormData(fd, {
+        actionId: "test/u.mjs#upload2",
+        resolveServerFunctionMeta: resolveMeta,
+        validateArg,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DecodeValidationError);
+      expect(err.reason).toBe("unknown_entry");
+      expect(err.original).toEqual({ entry: "role" });
+    }
+  });
+
+  test("unknown:'drop' silently skips undeclared entries", async () => {
+    const formSpec = {
+      _kind: "formdata",
+      entries: { title: string() },
+      unknown: "drop",
+    };
+    registerAction("test/u.mjs", "upload3", {
+      validate: [formSpec],
+    });
+    const fd = makeFormBody(["$K1"], {
+      "1_title": "ok",
+      "1_role": "admin", // dropped
+    });
+    const [resultFd] = decodeReplyFromFormData(fd, {
+      actionId: "test/u.mjs#upload3",
+      resolveServerFunctionMeta: resolveMeta,
+      validateArg,
+    });
+    expect(resultFd.get("title")).toBe("ok");
+    expect(resultFd.get("role")).toBe(null);
+  });
+
+  test("file maxBytes exceeded → max_bytes_exceeded", async () => {
+    const formSpec = {
+      _kind: "formdata",
+      entries: {
+        photo: { _kind: "file", maxBytes: 4 },
+      },
+    };
+    registerAction("test/u.mjs", "upload4", {
+      validate: [formSpec],
+    });
+    const photo = new File([new Uint8Array(8)], "p.png", { type: "image/png" });
+    const fd = makeFormBody(["$K1"], { "1_photo": photo });
+    try {
+      decodeReplyFromFormData(fd, {
+        actionId: "test/u.mjs#upload4",
+        resolveServerFunctionMeta: resolveMeta,
+        validateArg,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DecodeValidationError);
+      expect(err.reason).toBe("max_bytes_exceeded");
+      expect(err.original.size).toBe(8);
+      expect(err.original.limit).toBe(4);
+    }
+  });
+
+  test("file mime not allowed → mime_not_allowed", async () => {
+    const formSpec = {
+      _kind: "formdata",
+      entries: {
+        photo: { _kind: "file", mime: ["image/png"] },
+      },
+    };
+    registerAction("test/u.mjs", "upload5", {
+      validate: [formSpec],
+    });
+    const photo = new File([new Uint8Array(2)], "p.gif", { type: "image/gif" });
+    const fd = makeFormBody(["$K1"], { "1_photo": photo });
+    try {
+      decodeReplyFromFormData(fd, {
+        actionId: "test/u.mjs#upload5",
+        resolveServerFunctionMeta: resolveMeta,
+        validateArg,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DecodeValidationError);
+      expect(err.reason).toBe("mime_not_allowed");
+      expect(err.original.mime).toBe("image/gif");
+    }
+  });
+
+  test("optional file entry — missing accepted", async () => {
+    const formSpec = {
+      _kind: "formdata",
+      entries: {
+        photo: { _kind: "file", optional: true },
+      },
+    };
+    registerAction("test/u.mjs", "upload6", {
+      validate: [formSpec],
+    });
+    const fd = makeFormBody(["$K1"], {});
+    const [resultFd] = decodeReplyFromFormData(fd, {
+      actionId: "test/u.mjs#upload6",
+      resolveServerFunctionMeta: resolveMeta,
+      validateArg,
+    });
+    expect(resultFd.get("photo")).toBe(null);
+  });
+
+  test("required file entry missing → missing_entry", async () => {
+    const formSpec = {
+      _kind: "formdata",
+      entries: {
+        photo: { _kind: "file" },
+      },
+    };
+    registerAction("test/u.mjs", "upload7", {
+      validate: [formSpec],
+    });
+    const fd = makeFormBody(["$K1"], {});
+    try {
+      decodeReplyFromFormData(fd, {
+        actionId: "test/u.mjs#upload7",
+        resolveServerFunctionMeta: resolveMeta,
+        validateArg,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DecodeValidationError);
+      expect(err.reason).toBe("missing_entry");
+    }
+  });
+
+  test("formData slot expects $K reference; bare value rejected", async () => {
+    const formSpec = {
+      _kind: "formdata",
+      entries: { x: string() },
+    };
+    registerAction("test/u.mjs", "upload8", {
+      validate: [formSpec],
+    });
+    // Wire shape: arg slot 0 is a string, not a $K reference.
+    const fd = makeFormBody(["just a string"], {});
+    try {
+      decodeReplyFromFormData(fd, {
+        actionId: "test/u.mjs#upload8",
+        resolveServerFunctionMeta: resolveMeta,
+        validateArg,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DecodeValidationError);
+      expect(err.reason).toBe("wire_shape_mismatch");
+    }
+  });
+
+  test("custom validate returning false → custom_validate_failed", async () => {
+    const formSpec = {
+      _kind: "formdata",
+      entries: {
+        photo: {
+          _kind: "file",
+          validate: () => false, // always reject
+        },
+      },
+    };
+    registerAction("test/u.mjs", "upload9", {
+      validate: [formSpec],
+    });
+    const photo = new File([new Uint8Array(1)], "p.png", { type: "image/png" });
+    const fd = makeFormBody(["$K1"], { "1_photo": photo });
+    try {
+      decodeReplyFromFormData(fd, {
+        actionId: "test/u.mjs#upload9",
+        resolveServerFunctionMeta: resolveMeta,
+        validateArg,
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DecodeValidationError);
+      expect(err.reason).toBe("custom_validate_failed");
+    }
+  });
+});
+
+// ─── Wire-aware helpers for the rest of the Flight protocol ──────────────
+//
+// These tests round-trip values through `encodeReply` (client) →
+// `decodeReply` (server with meta), exercising the same wire format the
+// runtime emits. A fake host hook provides actionId / meta resolution
+// and the same Standard-Schema bridge as above.
+
+async function decodeWith(actionId, body) {
+  return decodeReply(body, {
+    actionId,
+    resolveServerFunctionMeta: resolveMeta,
+    validateArg,
+  });
+}
+
+describe("decodeReply — arrayBuffer slot", () => {
+  test("accepts an ArrayBuffer within maxBytes", async () => {
+    registerAction("test/buf.mjs", "ab1", {
+      validate: [{ _kind: "arrayBuffer", maxBytes: 16 }],
+    });
+    const ab = new Uint8Array([1, 2, 3, 4]).buffer;
+    const body = await encodeReply([ab]);
+    const out = await decodeWith("test/buf.mjs#ab1", body);
+    expect(out[0]).toBeInstanceOf(ArrayBuffer);
+    expect(out[0].byteLength).toBe(4);
+  });
+
+  test("rejects oversize ArrayBuffer with max_bytes_exceeded", async () => {
+    registerAction("test/buf.mjs", "ab2", {
+      validate: [{ _kind: "arrayBuffer", maxBytes: 4 }],
+    });
+    const ab = new Uint8Array(16).buffer;
+    const body = await encodeReply([ab]);
+    try {
+      await decodeWith("test/buf.mjs#ab2", body);
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DecodeValidationError);
+      expect(err.reason).toBe("max_bytes_exceeded");
+      expect(err.original).toMatchObject({ size: 16, limit: 4 });
+    }
+  });
+
+  test("rejects non-ArrayBuffer with wire_shape_mismatch", async () => {
+    registerAction("test/buf.mjs", "ab3", {
+      validate: [{ _kind: "arrayBuffer" }],
+    });
+    const body = await encodeReply(["not a buffer"]);
+    try {
+      await decodeWith("test/buf.mjs#ab3", body);
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DecodeValidationError);
+      expect(err.reason).toBe("wire_shape_mismatch");
+    }
+  });
+});
+
+describe("decodeReply — typedArray slot", () => {
+  test("accepts a value matching the constructor allowlist", async () => {
+    registerAction("test/ta.mjs", "ta1", {
+      validate: [{ _kind: "typedArray", ctor: [Uint8Array], maxBytes: 16 }],
+    });
+    const arr = new Uint8Array([1, 2, 3, 4]);
+    const body = await encodeReply([arr]);
+    const out = await decodeWith("test/ta.mjs#ta1", body);
+    expect(out[0]).toBeInstanceOf(Uint8Array);
+    expect(Array.from(out[0])).toEqual([1, 2, 3, 4]);
+  });
+
+  test("rejects a non-listed constructor with wire_shape_mismatch", async () => {
+    registerAction("test/ta.mjs", "ta2", {
+      validate: [{ _kind: "typedArray", ctor: [Uint8Array] }],
+    });
+    const arr = new Float32Array([1.5]);
+    const body = await encodeReply([arr]);
+    try {
+      await decodeWith("test/ta.mjs#ta2", body);
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DecodeValidationError);
+      expect(err.reason).toBe("wire_shape_mismatch");
+      expect(err.original).toMatchObject({
+        expected: "Uint8Array",
+        received: "Float32Array",
+      });
+    }
+  });
+
+  test("respects maxBytes on the typed-array's byteLength", async () => {
+    registerAction("test/ta.mjs", "ta3", {
+      validate: [{ _kind: "typedArray", maxBytes: 4 }],
+    });
+    const arr = new Uint8Array(8);
+    const body = await encodeReply([arr]);
+    try {
+      await decodeWith("test/ta.mjs#ta3", body);
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DecodeValidationError);
+      expect(err.reason).toBe("max_bytes_exceeded");
+    }
+  });
+});
+
+describe("decodeReply — map slot", () => {
+  test("accepts a Map within maxSize and inner schemas", async () => {
+    registerAction("test/m.mjs", "m1", {
+      validate: [
+        {
+          _kind: "map",
+          maxSize: 5,
+          key: string(),
+          value: number(),
+        },
+      ],
+    });
+    const m = new Map([
+      ["a", 1],
+      ["b", 2],
+    ]);
+    const body = await encodeReply([m]);
+    const out = await decodeWith("test/m.mjs#m1", body);
+    expect(out[0]).toBeInstanceOf(Map);
+    expect(out[0].get("a")).toBe(1);
+    expect(out[0].get("b")).toBe(2);
+  });
+
+  test("rejects oversize Map with max_size_exceeded", async () => {
+    registerAction("test/m.mjs", "m2", {
+      validate: [{ _kind: "map", maxSize: 1 }],
+    });
+    const m = new Map([
+      ["a", 1],
+      ["b", 2],
+    ]);
+    const body = await encodeReply([m]);
+    try {
+      await decodeWith("test/m.mjs#m2", body);
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DecodeValidationError);
+      expect(err.reason).toBe("max_size_exceeded");
+    }
+  });
+
+  test("rejects values that fail the inner schema", async () => {
+    registerAction("test/m.mjs", "m3", {
+      validate: [{ _kind: "map", value: number() }],
+    });
+    const m = new Map([["a", "not-a-number"]]);
+    const body = await encodeReply([m]);
+    try {
+      await decodeWith("test/m.mjs#m3", body);
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DecodeValidationError);
+      expect(err.reason).toBe("validate_failed");
+    }
+  });
+});
+
+describe("decodeReply — set slot", () => {
+  test("accepts a Set within maxSize and per-item schema", async () => {
+    registerAction("test/s.mjs", "s1", {
+      validate: [{ _kind: "set", maxSize: 5, value: string() }],
+    });
+    const s = new Set(["a", "b"]);
+    const body = await encodeReply([s]);
+    const out = await decodeWith("test/s.mjs#s1", body);
+    expect(out[0]).toBeInstanceOf(Set);
+    expect(out[0].has("a")).toBe(true);
+  });
+
+  test("rejects oversize Set with max_size_exceeded", async () => {
+    registerAction("test/s.mjs", "s2", {
+      validate: [{ _kind: "set", maxSize: 1 }],
+    });
+    const body = await encodeReply([new Set(["a", "b", "c"])]);
+    try {
+      await decodeWith("test/s.mjs#s2", body);
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DecodeValidationError);
+      expect(err.reason).toBe("max_size_exceeded");
+    }
+  });
+});
+
+describe("decodeReply — stream slot", () => {
+  test("returns a ReadableStream and enforces maxChunks on consumption", async () => {
+    registerAction("test/st.mjs", "st1", {
+      validate: [{ _kind: "stream", maxChunks: 2 }],
+    });
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue("a");
+        controller.enqueue("b");
+        controller.enqueue("c");
+        controller.close();
+      },
+    });
+    const body = await encodeReply([stream]);
+    const out = await decodeWith("test/st.mjs#st1", body);
+    expect(out[0]).toBeInstanceOf(ReadableStream);
+
+    // Drain the wrapped stream — must error on the 3rd chunk.
+    const reader = out[0].getReader();
+    const r1 = await reader.read();
+    const r2 = await reader.read();
+    expect(r1.value).toBe("a");
+    expect(r2.value).toBe("b");
+    let caught;
+    try {
+      await reader.read();
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(DecodeValidationError);
+    expect(caught.reason).toBe("max_chunks_exceeded");
+  });
+
+  test("fast path: no bounds → stream not wrapped", async () => {
+    registerAction("test/st.mjs", "st2", {
+      validate: [{ _kind: "stream" }],
+    });
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue("only");
+        controller.close();
+      },
+    });
+    const body = await encodeReply([stream]);
+    const out = await decodeWith("test/st.mjs#st2", body);
+    const reader = out[0].getReader();
+    expect((await reader.read()).value).toBe("only");
+    expect((await reader.read()).done).toBe(true);
+  });
+});
+
+describe("decodeReply — asyncIterable slot", () => {
+  test("yields each item through the inner schema, capped at maxYields", async () => {
+    registerAction("test/ai.mjs", "ai1", {
+      validate: [{ _kind: "asyncIterable", maxYields: 2, value: string() }],
+    });
+    async function* source() {
+      yield "a";
+      yield "b";
+      yield "c";
+    }
+    const body = await encodeReply([source()]);
+    const out = await decodeWith("test/ai.mjs#ai1", body);
+
+    const collected = [];
+    let caught;
+    try {
+      for await (const v of out[0]) collected.push(v);
+    } catch (err) {
+      caught = err;
+    }
+    expect(collected).toEqual(["a", "b"]);
+    expect(caught).toBeInstanceOf(DecodeValidationError);
+    expect(caught.reason).toBe("max_yields_exceeded");
+  });
+
+  test("rejects items that fail the inner schema", async () => {
+    registerAction("test/ai.mjs", "ai2", {
+      validate: [{ _kind: "asyncIterable", value: number() }],
+    });
+    async function* source() {
+      yield 1;
+      yield "two"; // wrong type
+    }
+    const body = await encodeReply([source()]);
+    const out = await decodeWith("test/ai.mjs#ai2", body);
+    let caught;
+    try {
+      for await (const _value of out[0]) {
+        void _value;
+      }
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(DecodeValidationError);
+    expect(caught.reason).toBe("validate_failed");
+  });
+});
+
+describe("decodeReply — iterable slot", () => {
+  test("yields with bounds enforced on each next() pull", async () => {
+    registerAction("test/it.mjs", "it1", {
+      validate: [{ _kind: "iterable", maxYields: 1 }],
+    });
+    function* source() {
+      yield 1;
+      yield 2;
+    }
+    const body = await encodeReply([source()]);
+    const out = await decodeWith("test/it.mjs#it1", body);
+    const iterator = out[0][Symbol.iterator]();
+    expect(iterator.next().value).toBe(1);
+    expect(() => iterator.next()).toThrow(DecodeValidationError);
+  });
+});
+
+describe("decodeReply — promise slot", () => {
+  test("accepts a Promise resolving to a value matching inner schema", async () => {
+    registerAction("test/p.mjs", "p1", {
+      validate: [{ _kind: "promise", value: string() }],
+    });
+    const body = await encodeReply([Promise.resolve("hello")]);
+    const out = await decodeWith("test/p.mjs#p1", body);
+    expect(out[0]).toBeInstanceOf(Promise);
+    await expect(out[0]).resolves.toBe("hello");
+  });
+
+  test("rejects when resolved value fails the inner schema", async () => {
+    registerAction("test/p.mjs", "p2", {
+      validate: [{ _kind: "promise", value: number() }],
+    });
+    const body = await encodeReply([Promise.resolve("not a number")]);
+    const out = await decodeWith("test/p.mjs#p2", body);
+    let caught;
+    try {
+      await out[0];
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(DecodeValidationError);
+    expect(caught.reason).toBe("validate_failed");
+  });
+
+  test("no inner schema → resolves passthrough", async () => {
+    registerAction("test/p.mjs", "p3", {
+      validate: [{ _kind: "promise" }],
+    });
+    const body = await encodeReply([Promise.resolve({ any: "shape" })]);
+    const out = await decodeWith("test/p.mjs#p3", body);
+    await expect(out[0]).resolves.toEqual({ any: "shape" });
+  });
+});

--- a/packages/rsc/server/index.d.ts
+++ b/packages/rsc/server/index.d.ts
@@ -45,11 +45,83 @@ export function decodeFormState(
 ): [unknown, string, string, number] | null;
 
 /**
- * Register a server reference (action)
+ * Server-function metadata: per-arg `parse` and/or `validate` specs that
+ * drive the protocol-level slot-walk in `decodeReply` when registered via
+ * `registerServerReference(fn, id, name, meta)`.
+ *
+ * - Both arrays are indexed by *runtime arg slot i* — what the client
+ *   puts on the wire at position `i`, NOT the handler signature param
+ *   `i`. Bound captures (closure values) are server-emitted and travel
+ *   via the AEAD-protected action token; they are explicitly NOT
+ *   subject to slot-walk validation.
+ * - `parse[i]` runs after the value tree is materialized and before
+ *   `validate[i]`. Use it for type coercion or shape massage that
+ *   should run before schema validation.
+ * - `validate[i]` is either:
+ *     - a Standard Schema (Zod / Valibot / ArkType / …) — duck-typed
+ *       via the host-supplied `validateArg` hook; or
+ *     - a wire-aware spec carrying a `_kind` marker (e.g. `formData`,
+ *       `file`, `blob` from `@lazarv/react-server/function`) — these
+ *       drive the decoder's wire-shape enforcement before any
+ *       value-level walk.
+ */
+export interface ServerFunctionMeta {
+  parse?: Array<((value: unknown) => unknown) | undefined>;
+  validate?: Array<unknown>;
+}
+
+/**
+ * Register a server reference (action). When `meta` is supplied the
+ * decoder applies per-slot parse/validate during the args walk and aborts
+ * on the first failure. Omit `meta` for bare `"use server"` actions —
+ * back-compat is preserved.
  */
 export function registerServerReference<
   T extends (...args: unknown[]) => unknown,
->(fn: T, id: string, name: string): T;
+>(fn: T, id: string, name: string, meta?: ServerFunctionMeta): T;
+
+/**
+ * Look up the registered metadata for a server function by full id
+ * (`${moduleId}#${exportName}`). Returns `undefined` for bare actions
+ * (no meta registered) — that's the back-compat path.
+ */
+export function lookupServerFunctionMeta(
+  id: string
+): ServerFunctionMeta | undefined;
+
+/**
+ * Decode-time error base class. Subclassed by `DecodeLimitError` (limit
+ * exceeded) and `DecodeValidationError` (per-arg parse/validate failure).
+ */
+export class DecodeError extends Error {
+  code: string;
+}
+
+export class DecodeLimitError extends DecodeError {
+  limit: string;
+  value: number;
+}
+
+/**
+ * Raised by the slot-walk when a per-arg parse/validate rejects a slot.
+ * Carries:
+ *   - `argIndex` — which positional arg slot failed (or `-1` for
+ *                  request-shape-level rejections like wire_shape_mismatch
+ *                  on the bound channel)
+ *   - `actionId` — recovered (decrypted) action id, for log correlation
+ *   - `reason`   — coarse failure category for telemetry filtering
+ *   - `original` — underlying error from the schema library or a
+ *                  structured object from a wire-aware helper. Hosts use
+ *                  this for structured server logs but should NOT
+ *                  forward it to the client unmodified — it can leak
+ *                  details about expected input shape.
+ */
+export class DecodeValidationError extends DecodeError {
+  argIndex: number;
+  actionId: string | null;
+  reason: string;
+  original: unknown;
+}
 
 /**
  * Register a client reference

--- a/packages/rsc/server/index.mjs
+++ b/packages/rsc/server/index.mjs
@@ -18,6 +18,11 @@ export {
   createClientModuleProxy,
   createTemporaryReferenceSet,
   prerender,
+  // Server-function metadata registry — populated by `registerServerReference`
+  // when called with a 4th `meta` argument (typically through
+  // `@lazarv/react-server`'s `createFunction` helper). Looked up by hosts
+  // wiring `decodeReply`'s `resolveServerFunctionMeta` option.
+  lookupServerFunctionMeta,
   // Taint APIs
   taintUniqueValue,
   taintObjectReference,
@@ -30,3 +35,14 @@ export {
   setCurrentRequest,
   getCurrentRequest,
 } from "./shared.mjs";
+
+// Decode-time errors. Hosts catch these when wiring `decodeReply` to
+// translate them into protocol-level rejections (typically HTTP 400)
+// before any handler runs. `DecodeValidationError` is what the slot-walk
+// throws when a per-arg parse/validate fails — it carries `argIndex`,
+// `actionId`, `reason`, and `original` for structured server logging.
+export {
+  DecodeError,
+  DecodeLimitError,
+  DecodeValidationError,
+} from "./reply-decoder.mjs";

--- a/packages/rsc/server/reply-decoder.mjs
+++ b/packages/rsc/server/reply-decoder.mjs
@@ -101,6 +101,41 @@ export class DecodeLimitError extends DecodeError {
   }
 }
 
+/**
+ * Raised when a per-arg validator (or wire-aware helper like `formData`)
+ * rejects a slot during the protocol-level walk in `decodeReplyFromFormData`.
+ *
+ * The decoder aborts on the first failure: subsequent slots are not read,
+ * the args list is not bound to the action, and the handler never runs.
+ * This is the "validate as soon as we have id and meta" gate — anything
+ * later would already be letting the attack slip in.
+ *
+ * Carries:
+ *   - `argIndex` — which positional arg slot failed
+ *   - `actionId` — the recovered (decrypted) action id, for log correlation
+ *   - `reason`   — coarse failure category, useful for telemetry filtering
+ *   - `original` — the underlying error from the schema library (Zod's
+ *                  ZodError with `.issues`, ArkType's diagnostics, etc.)
+ *                  or a structured object from a wire-aware helper. Hosts
+ *                  use this for structured server logs but should NOT
+ *                  forward it to the client unmodified — it can leak
+ *                  details about expected input shape.
+ */
+export class DecodeValidationError extends DecodeError {
+  constructor({ argIndex, actionId, reason, original, message }) {
+    super(
+      message ??
+        `Server function arg ${argIndex} failed validation${actionId ? ` for ${actionId}` : ""}: ${reason}`
+    );
+    this.name = "DecodeValidationError";
+    this.code = "DECODE_VALIDATION";
+    this.argIndex = argIndex;
+    this.actionId = actionId;
+    this.reason = reason;
+    this.original = original;
+  }
+}
+
 // ─── Temporary reference proxy ─────────────────────────────────────────────
 
 const TEMPORARY_REFERENCE_TAG = Symbol.for("react.temporary.reference");
@@ -168,6 +203,26 @@ function buildReplyResponse(prefix, formData, options) {
     // When the hook is absent or returns null the decoder falls back to
     // the legacy behaviour (parsed.id used as-is, parsed.bound used as-is).
     _decryptServerReferenceId: options.decryptServerReferenceId ?? null,
+
+    // Server-function call context. When the dispatcher knows which action
+    // is being invoked (action id recovered from the encrypted token in
+    // the request header / form field), it sets `_actionId` here and
+    // optionally provides a `_resolveServerFunctionMeta(id)` hook plus a
+    // `_validateArg(schema, value, ctx)` hook. Together these drive
+    // per-slot parse/validate during the args walk in
+    // `decodeReplyFromFormData` / `decodeReplyFromString`. A failure
+    // throws `DecodeValidationError` and aborts the decode before the
+    // next slot is touched — see the "validate as soon as we have id and
+    // meta" contract in the docs. When meta is null/undefined the decoder
+    // falls through to its pre-meta behaviour (back-compat for bare
+    // `"use server"` actions).
+    _actionId: options.actionId ?? null,
+    _resolveServerFunctionMeta:
+      typeof options.resolveServerFunctionMeta === "function"
+        ? options.resolveServerFunctionMeta
+        : null,
+    _validateArg:
+      typeof options.validateArg === "function" ? options.validateArg : null,
   };
 
   if (formData) {
@@ -818,16 +873,817 @@ function createSyncIterator(response, model) {
 // ─── Top-level decode entry points ─────────────────────────────────────────
 
 /**
+ * Walk the root args array slot-by-slot, applying the host-supplied
+ * parse → validate per slot. Throws `DecodeValidationError` on the first
+ * failure and never touches subsequent slots — the "validate as soon as
+ * we have id and meta" gate, applied at the protocol layer.
+ *
+ * Returns the validated args array. Caller (the dispatcher) is responsible
+ * for prepending any token-recovered bound prefix before invoking the
+ * action handler — bound captures are not subject to this validation,
+ * they're integrity-protected by the action token.
+ */
+function walkArgsWithMeta(response, parsedRoot, meta, basePath) {
+  if (!Array.isArray(parsedRoot)) {
+    throw new DecodeError(
+      "Server function args must be a positional array at the root"
+    );
+  }
+  const actionId = response._actionId;
+  const out = Array.from({ length: parsedRoot.length });
+
+  for (let i = 0; i < parsedRoot.length; i++) {
+    const slotPath = basePath ? basePath + ":" + i : String(i);
+    const validateSpec = meta?.validate?.[i];
+    const parseFn = meta?.parse?.[i];
+
+    let value;
+
+    // Wire-aware dispatch: when the slot's spec carries a `_kind` marker
+    // (see `formData` / `file` / `blob` in
+    // @lazarv/react-server/function), the slot's
+    // materialization itself is driven by the spec — `walkValue` is
+    // bypassed and the wire-aware decoder enforces shape, size, and
+    // declared-key constraints before any value-level walk happens.
+    if (
+      validateSpec &&
+      typeof validateSpec === "object" &&
+      typeof validateSpec._kind === "string"
+    ) {
+      try {
+        value = decodeWireAwareSlot(
+          response,
+          parsedRoot[i],
+          validateSpec,
+          slotPath,
+          i
+        );
+      } catch (err) {
+        if (err instanceof DecodeValidationError) throw err;
+        throw new DecodeValidationError({
+          argIndex: i,
+          actionId,
+          reason: err.code ?? "wire_aware_decode_failed",
+          original: err,
+        });
+      }
+    } else {
+      // Standard path: walk the slot's value tree, then apply parse and
+      // validate against a Standard Schema (host-supplied via the
+      // `validateArg` hook so @lazarv/rsc stays library-pure).
+      value = walkValue(response, parsedRoot[i], slotPath, new WeakSet());
+
+      if (typeof parseFn === "function") {
+        try {
+          value = parseFn(value);
+        } catch (err) {
+          throw new DecodeValidationError({
+            argIndex: i,
+            actionId,
+            reason: "parse_failed",
+            original: err,
+          });
+        }
+      }
+
+      if (validateSpec) {
+        const validateArg = response._validateArg;
+        if (typeof validateArg !== "function") {
+          throw new DecodeError(
+            "Server function meta declares validate[" +
+              i +
+              "] but no `validateArg` host hook was provided to decodeReply. " +
+              "Pass options.validateArg from the dispatcher."
+          );
+        }
+        const result = validateArg(validateSpec, value, {
+          argIndex: i,
+          actionId,
+        });
+        if (!result || result.success !== true) {
+          throw new DecodeValidationError({
+            argIndex: i,
+            actionId,
+            reason: "validate_failed",
+            original: result ? result.error : null,
+          });
+        }
+        value = result.data;
+      }
+    }
+
+    out[i] = value;
+  }
+
+  return out;
+}
+
+/**
+ * Resolve the meta for the current `_actionId` via the host hook, if any.
+ * Returns null when no actionId is set, no hook is registered, or the hook
+ * returns a falsy value — all of which mean "fall through to the
+ * unvalidated walk" (back-compat for bare `"use server"` actions).
+ */
+function resolveMeta(response) {
+  if (!response._actionId || !response._resolveServerFunctionMeta) return null;
+  const meta = response._resolveServerFunctionMeta(response._actionId);
+  return meta || null;
+}
+
+/**
+ * Wire-aware slot dispatch. Currently handles `formdata`; `file` and `blob`
+ * surface as entry-level constraints inside `formdata` rather than as
+ * top-level slots (a top-level `file` arg would imply an entire request
+ * body that's just one File, which doesn't match the FormData wire format
+ * the runtime emits). Each branch below pairs a `_kind` marker with a
+ * Flight wire tag and enforces resource bounds the slot's schema
+ * declares — catching protocol-level overshoot before the handler ever
+ * reads the value.
+ */
+function decodeWireAwareSlot(response, rawSlot, spec, slotPath, argIndex) {
+  switch (spec._kind) {
+    case "formdata":
+      return decodeFormDataSlot(response, rawSlot, spec, slotPath, argIndex);
+    case "arrayBuffer":
+      return decodeArrayBufferSlot(response, rawSlot, spec, slotPath, argIndex);
+    case "typedArray":
+      return decodeTypedArraySlot(response, rawSlot, spec, slotPath, argIndex);
+    case "map":
+      return decodeMapSlot(response, rawSlot, spec, slotPath, argIndex);
+    case "set":
+      return decodeSetSlot(response, rawSlot, spec, slotPath, argIndex);
+    case "stream":
+      return decodeStreamSlot(response, rawSlot, spec, slotPath, argIndex);
+    case "asyncIterable":
+      return decodeAsyncIterableSlot(
+        response,
+        rawSlot,
+        spec,
+        slotPath,
+        argIndex
+      );
+    case "iterable":
+      return decodeIterableSlot(response, rawSlot, spec, slotPath, argIndex);
+    case "promise":
+      return decodePromiseSlot(response, rawSlot, spec, slotPath, argIndex);
+    default:
+      throw new DecodeError(
+        "Unknown wire-aware spec kind: " + JSON.stringify(spec._kind)
+      );
+  }
+}
+
+/**
+ * Wire-aware decode of a `formData(shape, { unknown })` slot.
+ *
+ * The slot's raw value must be a `$K<partIdOrPath>` tag pointing at a
+ * sub-FormData. Instead of the legacy prefix-scan in `decodeFormDataRef`,
+ * which copies every wire entry whose key starts with the slot's prefix
+ * into the result, this function looks up *only* the entries declared in
+ * `spec.entries` by exact key. Anything else on the wire is either:
+ *
+ *   - rejected (`unknown: "reject"`, the default), so attacker-injected
+ *     extras like `5_role=admin` cause the request to fail before the
+ *     handler runs;
+ *   - silently dropped (`unknown: "drop"`), useful for forms that include
+ *     React-managed hidden fields the schema doesn't enumerate;
+ *   - kept (`unknown: "allow"`) — escape hatch, documented as unsafe.
+ *
+ * Per-entry constraints (`file({...})`, `blob({...})`, or a Standard
+ * Schema) are applied at materialization time. File size and MIME are
+ * checked synchronously against `Blob.size` / `Blob.type` before the
+ * entry is added to the result FormData. Schema validation routes
+ * through the host's `validateArg` hook for library-agnostic dispatch.
+ *
+ * On any failure the function throws `DecodeValidationError` and aborts
+ * the slot walk — the next slot's bytes are never read.
+ */
+function decodeFormDataSlot(response, rawSlot, spec, slotPath, argIndex) {
+  const actionId = response._actionId;
+
+  // Slot must be a `$K<partIdOrPath>` reference. Anything else (a $D Date,
+  // a primitive, a $T temp-ref) is a wire-shape mismatch the schema is
+  // declaring shouldn't be accepted.
+  if (typeof rawSlot !== "string" || !rawSlot.startsWith("$K")) {
+    throw new DecodeValidationError({
+      argIndex,
+      actionId,
+      reason: "wire_shape_mismatch",
+      original: {
+        expected: "FormData ($K reference)",
+        receivedTag:
+          typeof rawSlot === "string" ? rawSlot.slice(0, 2) : typeof rawSlot,
+      },
+    });
+  }
+  if (!response._formData) {
+    throw new DecodeValidationError({
+      argIndex,
+      actionId,
+      reason: "wire_shape_mismatch",
+      original: { detail: "FormData reference outside of FormData body" },
+    });
+  }
+
+  const partIdOrPath = rawSlot.slice(2);
+  const bareKey = response._prefix + partIdOrPath;
+  const entryPrefix = bareKey + "_";
+
+  // Reject the legacy "bare File at the same key" form — `formData`
+  // declares an object-like sub-FormData; if the wire shape is a single
+  // Blob/File at the bare key, that's not what the schema asked for.
+  const bareEntries = response._formData.getAll(bareKey);
+  for (const v of bareEntries) {
+    if (typeof v !== "string") {
+      throw new DecodeValidationError({
+        argIndex,
+        actionId,
+        reason: "wire_shape_mismatch",
+        original: {
+          detail:
+            "formData expects a sub-FormData reference but the wire " +
+            "carried a bare Blob/File at the same key",
+        },
+      });
+    }
+  }
+
+  const entries = spec.entries || {};
+  const declaredNames = new Set(Object.keys(entries));
+  const unknownPolicy = spec.unknown ?? "reject";
+
+  const result = new FormData();
+
+  // First pass: walk declared entries in declaration order. Each per-entry
+  // constraint runs as soon as the entry is read, before the next entry
+  // is touched. A failure aborts immediately.
+  for (const name of declaredNames) {
+    const constraint = entries[name];
+    const wireKey = entryPrefix + name;
+    const wireValues = response._formData.getAll(wireKey);
+
+    if (wireValues.length === 0) {
+      // Entry not present on the wire. Whether this is a failure depends
+      // on the constraint — defer to it via the host's validateArg hook
+      // (Zod's `.optional()` would accept undefined; `.string()` would
+      // reject it). Wire-aware constraints (_kind: "file" / "blob") are
+      // strict by default — declared = required.
+      if (
+        constraint &&
+        typeof constraint === "object" &&
+        typeof constraint._kind === "string"
+      ) {
+        if (constraint.optional !== true) {
+          throw new DecodeValidationError({
+            argIndex,
+            actionId,
+            reason: "missing_entry",
+            original: { entry: name },
+          });
+        }
+        continue;
+      }
+      // Standard schema: pass `undefined` to the validator and let it decide.
+      const validateArg = response._validateArg;
+      if (typeof validateArg === "function" && constraint) {
+        const r = validateArg(constraint, undefined, {
+          argIndex,
+          actionId,
+          entry: name,
+        });
+        if (!r || r.success !== true) {
+          throw new DecodeValidationError({
+            argIndex,
+            actionId,
+            reason: "validate_failed",
+            original: r ? r.error : null,
+          });
+        }
+        if (r.data !== undefined) {
+          result.append(name, r.data);
+        }
+      }
+      continue;
+    }
+
+    // Multi-value semantics aren't part of this contract — a declared
+    // entry is one value. If the wire has multiple, that's a wire-shape
+    // mismatch worth rejecting.
+    if (wireValues.length > 1) {
+      throw new DecodeValidationError({
+        argIndex,
+        actionId,
+        reason: "duplicate_entry",
+        original: { entry: name, count: wireValues.length },
+      });
+    }
+
+    const wireValue = wireValues[0];
+    const validatedValue = applyEntryConstraint(
+      response,
+      constraint,
+      wireValue,
+      argIndex,
+      name,
+      slotPath
+    );
+    if (validatedValue !== undefined) {
+      result.append(name, validatedValue);
+    }
+  }
+
+  // Second pass: enforce the unknown-key policy. We walk the backing
+  // FormData once; any key starting with `entryPrefix` whose suffix isn't
+  // in the declared set is "unknown".
+  if (unknownPolicy === "reject" || unknownPolicy === "allow") {
+    for (const k of response._formData.keys()) {
+      if (!k.startsWith(entryPrefix)) continue;
+      const suffix = k.slice(entryPrefix.length);
+      if (declaredNames.has(suffix)) continue;
+      if (unknownPolicy === "reject") {
+        throw new DecodeValidationError({
+          argIndex,
+          actionId,
+          reason: "unknown_entry",
+          original: { entry: suffix },
+        });
+      }
+      // "allow": copy through unvalidated.
+      const vs = response._formData.getAll(k);
+      for (const v of vs) result.append(suffix, v);
+    }
+  }
+  // "drop": silently skip — the result already only contains declared entries.
+
+  return result;
+}
+
+/**
+ * Apply a single per-entry constraint to a wire value (string, File, or
+ * Blob from FormData). Returns the validated value to put in the result,
+ * or undefined to skip. Throws `DecodeValidationError` on failure.
+ */
+function applyEntryConstraint(
+  response,
+  constraint,
+  wireValue,
+  argIndex,
+  entryName
+) {
+  const actionId = response._actionId;
+
+  // Wire-aware: file / blob constraints check Blob.size and Blob.type
+  // synchronously, before the entry is added to the result FormData.
+  // The bytes themselves are already buffered by the multipart parser,
+  // bounded by the request-level `maxBytes` limit; this gates the
+  // per-entry cap and MIME allowlist.
+  if (
+    constraint &&
+    typeof constraint === "object" &&
+    (constraint._kind === "file" || constraint._kind === "blob")
+  ) {
+    if (typeof wireValue === "string") {
+      throw new DecodeValidationError({
+        argIndex,
+        actionId,
+        reason: "wire_shape_mismatch",
+        original: {
+          entry: entryName,
+          detail: "expected " + constraint._kind + ", got string",
+        },
+      });
+    }
+    if (typeof wireValue.size !== "number") {
+      throw new DecodeValidationError({
+        argIndex,
+        actionId,
+        reason: "wire_shape_mismatch",
+        original: { entry: entryName, detail: "value is not a Blob/File" },
+      });
+    }
+    if (
+      typeof constraint.maxBytes === "number" &&
+      wireValue.size > constraint.maxBytes
+    ) {
+      throw new DecodeValidationError({
+        argIndex,
+        actionId,
+        reason: "max_bytes_exceeded",
+        original: {
+          entry: entryName,
+          size: wireValue.size,
+          limit: constraint.maxBytes,
+        },
+      });
+    }
+    if (Array.isArray(constraint.mime) && constraint.mime.length > 0) {
+      const mime = wireValue.type || "";
+      if (!constraint.mime.includes(mime)) {
+        throw new DecodeValidationError({
+          argIndex,
+          actionId,
+          reason: "mime_not_allowed",
+          original: {
+            entry: entryName,
+            mime,
+            allowed: constraint.mime,
+          },
+        });
+      }
+    }
+    // `validate` callback (custom check, e.g. magic-byte detection). We
+    // call it synchronously here; if it returns a Promise the caller
+    // awaits in their own dispatch — but since `decodeFormDataSlot`
+    // itself is sync, async `validate` callbacks run via the optional
+    // `validateArg` host hook only in the non-wire-aware branch. For
+    // wire-aware constraints we keep `validate` strictly sync.
+    if (typeof constraint.validate === "function") {
+      let ok;
+      try {
+        ok = constraint.validate(wireValue);
+      } catch (err) {
+        throw new DecodeValidationError({
+          argIndex,
+          actionId,
+          reason: "custom_validate_failed",
+          original: { entry: entryName, error: err },
+        });
+      }
+      if (ok !== true) {
+        throw new DecodeValidationError({
+          argIndex,
+          actionId,
+          reason: "custom_validate_failed",
+          original: { entry: entryName, returned: ok },
+        });
+      }
+    }
+    return wireValue;
+  }
+
+  // Standard Schema entry constraint. Route through the host's
+  // validateArg hook — same library-agnostic dispatch as the top-level
+  // arg path, just scoped to a single FormData entry.
+  if (constraint) {
+    const validateArg = response._validateArg;
+    if (typeof validateArg !== "function") {
+      throw new DecodeError(
+        "formData entry `" +
+          entryName +
+          "` declares a schema but no `validateArg` host hook was provided " +
+          "to decodeReply. Pass options.validateArg from the dispatcher."
+      );
+    }
+    const r = validateArg(constraint, wireValue, {
+      argIndex,
+      actionId,
+      entry: entryName,
+    });
+    if (!r || r.success !== true) {
+      throw new DecodeValidationError({
+        argIndex,
+        actionId,
+        reason: "validate_failed",
+        original: r ? r.error : null,
+      });
+    }
+    return r.data;
+  }
+
+  // No constraint declared for this entry — pass through (legitimate when
+  // the user wants to declare an entry as "present, but no validation").
+  return wireValue;
+}
+
+// ─── Wire-aware decoders for the rest of the Flight protocol ─────────────
+
+/**
+ * Materialize a slot via `walkValue` and assert the result is one of
+ * the expected platform types. Used by all the post-walk wire-aware
+ * decoders below to share their wire-shape mismatch reporting.
+ */
+function materializeSlot(response, rawSlot, slotPath) {
+  return walkValue(response, rawSlot, slotPath, new WeakSet());
+}
+
+function wireMismatch(argIndex, actionId, expected, detail) {
+  throw new DecodeValidationError({
+    argIndex,
+    actionId,
+    reason: "wire_shape_mismatch",
+    original: detail ? { expected, ...detail } : { expected },
+  });
+}
+
+function decodeArrayBufferSlot(response, rawSlot, spec, slotPath, argIndex) {
+  const value = materializeSlot(response, rawSlot, slotPath);
+  if (!(value instanceof ArrayBuffer)) {
+    wireMismatch(argIndex, response._actionId, "ArrayBuffer", {
+      received: typeof value,
+    });
+  }
+  if (typeof spec.maxBytes === "number" && value.byteLength > spec.maxBytes) {
+    throw new DecodeValidationError({
+      argIndex,
+      actionId: response._actionId,
+      reason: "max_bytes_exceeded",
+      original: { size: value.byteLength, limit: spec.maxBytes },
+    });
+  }
+  return value;
+}
+
+function decodeTypedArraySlot(response, rawSlot, spec, slotPath, argIndex) {
+  const value = materializeSlot(response, rawSlot, slotPath);
+  // ArrayBuffer.isView covers TypedArrays and DataView. We accept both
+  // here — the constructor allowlist is what narrows further.
+  if (!ArrayBuffer.isView(value)) {
+    wireMismatch(argIndex, response._actionId, "TypedArray", {
+      received: typeof value,
+    });
+  }
+  if (Array.isArray(spec.ctor) && spec.ctor.length > 0) {
+    // Compare by constructor reference (`value instanceof Ctor`) rather
+    // than by name — references are tamper-evident across realm
+    // boundaries and TS-inferable, and they're what the user actually
+    // wrote in the spec.
+    const matched = spec.ctor.some((C) => value instanceof C);
+    if (!matched) {
+      const expected = spec.ctor.map((C) => C?.name ?? "(unknown)").join(" | ");
+      const received = value.constructor?.name ?? "(unknown)";
+      wireMismatch(argIndex, response._actionId, expected, { received });
+    }
+  }
+  if (typeof spec.maxBytes === "number" && value.byteLength > spec.maxBytes) {
+    throw new DecodeValidationError({
+      argIndex,
+      actionId: response._actionId,
+      reason: "max_bytes_exceeded",
+      original: { size: value.byteLength, limit: spec.maxBytes },
+    });
+  }
+  return value;
+}
+
+/**
+ * Apply an inner schema (Standard Schema via the host's `validateArg`
+ * hook) to a single value, returning the validated data or throwing
+ * `DecodeValidationError`. Shared between map / set / iterable / async
+ * iterable / promise inner-value validation.
+ */
+function applyInner(response, schema, value, argIndex, where) {
+  const validateArg = response._validateArg;
+  if (typeof validateArg !== "function") {
+    throw new DecodeError(
+      "Slot " +
+        argIndex +
+        " declares an inner `" +
+        where +
+        "` schema but no `validateArg` host hook was provided to decodeReply."
+    );
+  }
+  const result = validateArg(schema, value, {
+    argIndex,
+    actionId: response._actionId,
+  });
+  if (!result || result.success !== true) {
+    throw new DecodeValidationError({
+      argIndex,
+      actionId: response._actionId,
+      reason: "validate_failed",
+      original: result ? result.error : null,
+    });
+  }
+  return result.data;
+}
+
+function decodeMapSlot(response, rawSlot, spec, slotPath, argIndex) {
+  const value = materializeSlot(response, rawSlot, slotPath);
+  if (!(value instanceof Map)) {
+    wireMismatch(argIndex, response._actionId, "Map", {
+      received: typeof value,
+    });
+  }
+  if (typeof spec.maxSize === "number" && value.size > spec.maxSize) {
+    throw new DecodeValidationError({
+      argIndex,
+      actionId: response._actionId,
+      reason: "max_size_exceeded",
+      original: { size: value.size, limit: spec.maxSize },
+    });
+  }
+  if (spec.key == null && spec.value == null) return value;
+  const out = new Map();
+  for (const [k, v] of value) {
+    const validatedKey = spec.key
+      ? applyInner(response, spec.key, k, argIndex, "key")
+      : k;
+    const validatedValue = spec.value
+      ? applyInner(response, spec.value, v, argIndex, "value")
+      : v;
+    out.set(validatedKey, validatedValue);
+  }
+  return out;
+}
+
+function decodeSetSlot(response, rawSlot, spec, slotPath, argIndex) {
+  const value = materializeSlot(response, rawSlot, slotPath);
+  if (!(value instanceof Set)) {
+    wireMismatch(argIndex, response._actionId, "Set", {
+      received: typeof value,
+    });
+  }
+  if (typeof spec.maxSize === "number" && value.size > spec.maxSize) {
+    throw new DecodeValidationError({
+      argIndex,
+      actionId: response._actionId,
+      reason: "max_size_exceeded",
+      original: { size: value.size, limit: spec.maxSize },
+    });
+  }
+  if (spec.value == null) return value;
+  const out = new Set();
+  for (const item of value) {
+    out.add(applyInner(response, spec.value, item, argIndex, "value"));
+  }
+  return out;
+}
+
+function decodeStreamSlot(response, rawSlot, spec, slotPath, argIndex) {
+  const value = materializeSlot(response, rawSlot, slotPath);
+  if (
+    !value ||
+    typeof value !== "object" ||
+    typeof value.pipeThrough !== "function"
+  ) {
+    wireMismatch(argIndex, response._actionId, "ReadableStream", {
+      received: typeof value,
+    });
+  }
+  // Fast path: no bounds declared — no need to wrap.
+  if (typeof spec.maxChunks !== "number" && typeof spec.maxBytes !== "number") {
+    return value;
+  }
+  let chunkCount = 0;
+  let byteCount = 0;
+  const actionId = response._actionId;
+  return value.pipeThrough(
+    new TransformStream({
+      transform(chunk, controller) {
+        chunkCount++;
+        if (typeof spec.maxChunks === "number" && chunkCount > spec.maxChunks) {
+          controller.error(
+            new DecodeValidationError({
+              argIndex,
+              actionId,
+              reason: "max_chunks_exceeded",
+              original: { count: chunkCount, limit: spec.maxChunks },
+            })
+          );
+          return;
+        }
+        if (typeof spec.maxBytes === "number") {
+          // Bytes for binary streams (Uint8Array / ArrayBufferView), char
+          // count for text streams. Mixed-mode streams use whichever is
+          // available on the chunk.
+          const chunkSize =
+            chunk?.byteLength ?? (typeof chunk === "string" ? chunk.length : 0);
+          byteCount += chunkSize;
+          if (byteCount > spec.maxBytes) {
+            controller.error(
+              new DecodeValidationError({
+                argIndex,
+                actionId,
+                reason: "max_bytes_exceeded",
+                original: { size: byteCount, limit: spec.maxBytes },
+              })
+            );
+            return;
+          }
+        }
+        controller.enqueue(chunk);
+      },
+    })
+  );
+}
+
+function isAsyncIterable(value) {
+  return (
+    value &&
+    typeof value === "object" &&
+    typeof value[Symbol.asyncIterator] === "function"
+  );
+}
+
+function isSyncIterable(value) {
+  return (
+    value &&
+    typeof value === "object" &&
+    typeof value[Symbol.iterator] === "function"
+  );
+}
+
+function decodeAsyncIterableSlot(response, rawSlot, spec, slotPath, argIndex) {
+  const value = materializeSlot(response, rawSlot, slotPath);
+  if (!isAsyncIterable(value)) {
+    wireMismatch(argIndex, response._actionId, "AsyncIterable", {
+      received: typeof value,
+    });
+  }
+  const actionId = response._actionId;
+  const inner = spec.value;
+  // Wrap as a fresh async iterable that enforces bounds and inner schema.
+  return {
+    async *[Symbol.asyncIterator]() {
+      let yielded = 0;
+      for await (const item of value) {
+        yielded++;
+        if (typeof spec.maxYields === "number" && yielded > spec.maxYields) {
+          throw new DecodeValidationError({
+            argIndex,
+            actionId,
+            reason: "max_yields_exceeded",
+            original: { count: yielded, limit: spec.maxYields },
+          });
+        }
+        yield inner
+          ? applyInner(response, inner, item, argIndex, "value")
+          : item;
+      }
+    },
+  };
+}
+
+function decodeIterableSlot(response, rawSlot, spec, slotPath, argIndex) {
+  const value = materializeSlot(response, rawSlot, slotPath);
+  if (!isSyncIterable(value)) {
+    wireMismatch(argIndex, response._actionId, "Iterable", {
+      received: typeof value,
+    });
+  }
+  const actionId = response._actionId;
+  const inner = spec.value;
+  return {
+    *[Symbol.iterator]() {
+      let yielded = 0;
+      for (const item of value) {
+        yielded++;
+        if (typeof spec.maxYields === "number" && yielded > spec.maxYields) {
+          throw new DecodeValidationError({
+            argIndex,
+            actionId,
+            reason: "max_yields_exceeded",
+            original: { count: yielded, limit: spec.maxYields },
+          });
+        }
+        yield inner
+          ? applyInner(response, inner, item, argIndex, "value")
+          : item;
+      }
+    },
+  };
+}
+
+function decodePromiseSlot(response, rawSlot, spec, slotPath, argIndex) {
+  const value = materializeSlot(response, rawSlot, slotPath);
+  if (!value || typeof value.then !== "function") {
+    wireMismatch(argIndex, response._actionId, "Promise", {
+      received: typeof value,
+    });
+  }
+  if (spec.value == null) return value;
+  // Wrap with a downstream `.then` so the resolved value is validated
+  // before the handler observes it. Rejection paths pass through
+  // unchanged — they're already error states.
+  return value.then((resolved) =>
+    applyInner(response, spec.value, resolved, argIndex, "value")
+  );
+}
+
+/**
  * Decode a JSON-string body (no outlined rows).
+ *
+ * When the host provides `actionId` + `resolveServerFunctionMeta` and the
+ * resolved meta declares per-arg parse/validate, the root array is walked
+ * slot-by-slot under those rules. Otherwise the legacy whole-tree walk
+ * runs (back-compat for bare actions and non-server-function callers of
+ * `decodeReply`).
  */
 export function decodeReplyFromString(body, options = {}) {
   const response = buildReplyResponse("", null, options);
   const parsed = JSON.parse(body, forbiddenReviver);
+  const meta = resolveMeta(response);
+  if (meta) {
+    return walkArgsWithMeta(response, parsed, meta, "0");
+  }
   return walkValue(response, parsed, "0", new WeakSet());
 }
 
 /**
  * Decode a FormData body. Root row lives at `<prefix>0`.
+ *
+ * Same meta-driven slot-walk as `decodeReplyFromString` when the host
+ * supplies `actionId` + `resolveServerFunctionMeta`.
  */
 export function decodeReplyFromFormData(formData, options = {}) {
   const prefix = options.formFieldPrefix ?? "";
@@ -837,6 +1693,24 @@ export function decodeReplyFromFormData(formData, options = {}) {
   if (typeof rootRaw !== "string") {
     return formData;
   }
+
+  const meta = resolveMeta(response);
+  if (meta) {
+    // Slot-by-slot walk under the registered meta. The root JSON.parse
+    // still runs once — the per-slot recursion happens via walkValue
+    // inside the loop, with parse/validate gated on each slot.
+    let parsed;
+    try {
+      parsed = JSON.parse(rootRaw, forbiddenReviver);
+    } catch (err) {
+      throw new DecodeError(
+        "Failed to parse server function args JSON: " + err.message
+      );
+    }
+    return walkArgsWithMeta(response, parsed, meta, "0");
+  }
+
+  // No meta → legacy whole-tree walk (bare `"use server"` action).
   // Prime the root chunk with path "0" so $T tokens inside it get
   // structural identity matching the client-side encoder's path.
   response._chunks.set(0, {

--- a/packages/rsc/server/shared.mjs
+++ b/packages/rsc/server/shared.mjs
@@ -15,6 +15,7 @@
 import {
   decodeReplyFromString as _decodeReplyFromString,
   decodeReplyFromFormData as _decodeReplyFromFormData,
+  DecodeValidationError as _DecodeValidationError,
 } from "./reply-decoder.mjs";
 
 // React Flight Protocol constants
@@ -2654,10 +2655,55 @@ export function deserializeValue(value, options = {}, path = "") {
       }
 
       const action = loader(id);
-      const wireBound =
-        parsed.bound && Array.isArray(parsed.bound) && parsed.bound.length > 0
-          ? parsed.bound.map((arg) => deserializeValue(arg, options, path))
-          : null;
+      const wireBoundIsArray =
+        parsed.bound && Array.isArray(parsed.bound) && parsed.bound.length > 0;
+
+      // Defense-in-depth: when the action has registered meta (i.e., it was
+      // declared with `createFunction`) AND the encrypted token already
+      // delivered bound captures, any non-empty `parsed.bound` on the wire
+      // is a wire-shape mismatch — the trusted channel for closure
+      // captures is the AEAD-protected token, not the wire's `bound`
+      // field. Reject before the action is bound. This is a structural
+      // gate, not a value-level validation: bound captures themselves are
+      // hidden values and are not subject to per-arg parse/validate (see
+      // walkArgsWithMeta in reply-decoder.mjs for the user-input path).
+      const meta = serverFunctionMetaRegistry.get(id);
+      if (meta && tokenBound !== null && wireBoundIsArray) {
+        throw new _DecodeValidationError({
+          argIndex: -1,
+          actionId: id,
+          reason: "wire_shape_mismatch",
+          original: {
+            detail:
+              "bound captures must travel via the encrypted action token; " +
+              "wire-supplied `bound` is rejected for actions registered with createFunction",
+          },
+        });
+      }
+
+      // Bound-arg combined limit (parity with reply-decoder.mjs's
+      // `maxBoundArgs`). Pulled from `options.limits.maxBoundArgs` when
+      // the host supplies it; defaults to a permissive value otherwise so
+      // pre-meta callers keep working unchanged.
+      const maxBoundArgs =
+        typeof options.limits?.maxBoundArgs === "number"
+          ? options.limits.maxBoundArgs
+          : 1024;
+      const totalBoundLength =
+        (tokenBound ? tokenBound.length : 0) +
+        (wireBoundIsArray ? parsed.bound.length : 0);
+      if (totalBoundLength > maxBoundArgs) {
+        throw new _DecodeValidationError({
+          argIndex: -1,
+          actionId: id,
+          reason: "max_bound_args_exceeded",
+          original: { length: totalBoundLength, limit: maxBoundArgs },
+        });
+      }
+
+      const wireBound = wireBoundIsArray
+        ? parsed.bound.map((arg) => deserializeValue(arg, options, path))
+        : null;
 
       // No bound from any source.
       if (tokenBound === null && wireBound === null) {
@@ -2915,14 +2961,39 @@ export function decodeFormState(actionResult, body) {
 const serverReferenceRegistry = new Map();
 
 /**
+ * Registry of server-function metadata (parse + validate per-arg specs).
+ *
+ * Keyed by the same `${id}#${exportName}` full id used by
+ * `serverReferenceRegistry`, but populated only for actions that opted into
+ * validation via `registerServerReference(fn, id, name, meta)` (typically
+ * through `@lazarv/react-server`'s `createFunction` helper).
+ *
+ * Decoder hooks consult this map via `lookupServerFunctionMeta(id)` after
+ * recovering the actionId from an incoming request, and use the meta to
+ * drive per-slot parse/validate during the args walk — rejecting malformed
+ * payloads at the protocol layer, before any handler code runs.
+ *
+ * Bare server-action registrations leave this map untouched; their decode
+ * path is identical to the pre-meta behavior (back-compat).
+ */
+const serverFunctionMetaRegistry = new Map();
+
+/**
  * Register a server reference (action)
  *
  * @param {Function} action - The server action function
  * @param {string} id - The module ID
  * @param {string} exportName - The export name
+ * @param {object} [meta] - Optional metadata describing the action's call
+ *                          shape: `{ args?, parse?, validate? }`. When
+ *                          provided, the decoder applies parse → validate
+ *                          per slot during the args walk and aborts the
+ *                          decode on the first failure (see
+ *                          `decodeReplyFromFormData`). Omit for bare
+ *                          `"use server"` actions — back-compat is preserved.
  * @returns {Function} The registered action with metadata
  */
-export function registerServerReference(action, id, exportName) {
+export function registerServerReference(action, id, exportName, meta) {
   const fullId = `${id}#${exportName}`;
 
   // Create a wrapper that preserves bind behavior
@@ -2982,8 +3053,29 @@ export function registerServerReference(action, id, exportName) {
   }
 
   serverReferenceRegistry.set(fullId, serverAction);
+  if (meta != null) {
+    serverFunctionMetaRegistry.set(fullId, meta);
+  }
 
   return serverAction;
+}
+
+/**
+ * Look up the registered metadata for a server function by full id.
+ *
+ * Returns the `{ args?, parse?, validate? }` object passed to
+ * `registerServerReference(fn, id, name, meta)`, or `undefined` if no meta
+ * was registered (the bare back-compat path).
+ *
+ * Used by the reply decoder's slot-walk gate to drive per-arg parse and
+ * validate. Returning `undefined` makes the decoder skip those steps and
+ * fall through to the unvalidated walk.
+ *
+ * @param {string} id - The full id (`${moduleId}#${exportName}`).
+ * @returns {object | undefined}
+ */
+export function lookupServerFunctionMeta(id) {
+  return serverFunctionMetaRegistry.get(id);
 }
 
 /**

--- a/packages/rsc/types.d.ts
+++ b/packages/rsc/types.d.ts
@@ -178,6 +178,28 @@ export interface DecodeReplyLimits {
 }
 
 /**
+ * Result returned by `validateArg`. `success: true` means the value
+ * passed; `data` replaces the original (so coercive validators like
+ * Zod's `.transform()` flow back into the args list). `success: false`
+ * triggers a `DecodeValidationError` whose `original` field is `error`.
+ */
+export type ValidateArgResult =
+  | { success: true; data: unknown }
+  | { success: false; error: unknown };
+
+/**
+ * Host-supplied bridge from a Standard Schema (Zod / Valibot / ArkType / …)
+ * to the decoder's library-agnostic dispatch. The decoder does not import
+ * any schema library directly — the host is responsible for duck-typing
+ * the spec and invoking the right `safeParse` / `safeValidate` method.
+ */
+export type ValidateArgHook = (
+  spec: unknown,
+  value: unknown,
+  ctx: { argIndex: number; actionId: string | null; entry?: string }
+) => ValidateArgResult;
+
+/**
  * Options for decodeReply
  */
 export interface DecodeReplyOptions {
@@ -196,6 +218,46 @@ export interface DecodeReplyOptions {
    * Defaults match the decoder's built-in safe ceilings.
    */
   limits?: DecodeReplyLimits;
+
+  /**
+   * Hook invoked on the `id` field of a server-reference payload (the
+   * `parsed.id` in `{id, bound}`). When the host implements opaque
+   * AEAD-encrypted action tokens, this hook decrypts the token to
+   * recover the underlying action id and any server-emitted bound
+   * captures. The decoder treats `actionId` as authoritative for
+   * registry lookup, and prepends `bound` to any wire-supplied bound at
+   * bind time. Return `null` to fall through to the legacy behavior
+   * (parsed.id used as-is).
+   */
+  decryptServerReferenceId?: (
+    encryptedId: string
+  ) => { actionId: string; bound?: unknown[] } | null;
+
+  /**
+   * Recovered (decrypted) action id for the current request, set by the
+   * dispatcher *before* calling `decodeReply`. Together with
+   * `resolveServerFunctionMeta` this drives per-slot parse/validate
+   * during the args walk. Leave unset for non-server-function callers
+   * of `decodeReply`.
+   */
+  actionId?: string;
+
+  /**
+   * Look up the registered metadata for an action id (typically a thin
+   * wrapper around `lookupServerFunctionMeta`). When this resolves to a
+   * non-null value the decoder switches to the meta-driven slot-walk;
+   * when it resolves to null the decoder falls through to the legacy
+   * whole-tree walk (back-compat for bare `"use server"` actions).
+   */
+  resolveServerFunctionMeta?: (actionId: string) => unknown;
+
+  /**
+   * Library-agnostic Standard-Schema bridge. Required when meta declares
+   * `validate.args[i]` against a schema (Zod / Valibot / ArkType / …).
+   * Wire-aware constraints (`_kind: "file" | "blob" | "formdata"`) bypass
+   * this hook and are enforced directly by the decoder.
+   */
+  validateArg?: ValidateArgHook;
 }
 
 /**

--- a/test/__test__/server-function-validation.spec.mjs
+++ b/test/__test__/server-function-validation.spec.mjs
@@ -1,0 +1,378 @@
+import { hostname, page, server, waitForHydration } from "playground/utils";
+import { expect, test } from "vitest";
+
+/**
+ * Runtime-level E2E for `createFunction` slot-walk validation.
+ *
+ * What this asserts (and why each case matters):
+ *
+ *   - Happy path: declared schemas accept correct inputs and the
+ *     handler runs (proves the slot-walk path doesn't break the common
+ *     case).
+ *   - parse → validate ordering: `parse.args[0]` runs before
+ *     `validate.args[0]`, so a wire string can be coerced into a number
+ *     before the schema runs.
+ *   - Validation rejects → handler does NOT run: this is the load-bearing
+ *     security contract. The fixture's `tooShort` action sets a server-
+ *     side global if the handler ever executes; after the rejected call
+ *     we observe that global is still null (no handler invocation).
+ *   - formData wire-aware constraints: oversize / bad MIME /
+ *     unknown-key injection are all rejected at decode time, not
+ *     downstream, so the client receives an error and the upload
+ *     handler is never reached.
+ *   - Bare `"use server"` (no `createFunction` wrapper) keeps working
+ *     unchanged — back-compat is preserved.
+ *
+ * The fixture stashes either the success descriptor or
+ * `{ kind: "clientError", message }` on `window.__react_server_result__`
+ * so the assertions read a consistent shape regardless of path.
+ */
+
+const result = () =>
+  page.evaluate(() => window.__react_server_result__ ?? null);
+
+async function clickAndAwaitResult(testid) {
+  await page.evaluate(() => {
+    window.__react_server_result__ = undefined;
+  });
+  await page.getByTestId(testid).click();
+  // Poll for result; @lazarv/react-server resolves promises through
+  // RSC, so we wait until the global is set.
+  await page.waitForFunction(
+    () => window.__react_server_result__ !== undefined,
+    null,
+    { timeout: 5_000 }
+  );
+  return result();
+}
+
+test("createFunction slot-walk validation — happy path", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+
+  const r = await clickAndAwaitResult("v-greet-ok");
+  expect(r).toMatchObject({
+    kind: "ok",
+    name: "alice",
+    age: 30,
+    handlerRan: true,
+  });
+});
+
+test("createFunction rejects bad slot-0 type before handler runs", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+
+  const r = await clickAndAwaitResult("v-greet-bad-arg-0");
+  expect(r?.kind).toBe("clientError");
+});
+
+test("createFunction rejects bad slot-1 type", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+
+  const r = await clickAndAwaitResult("v-greet-bad-arg-1");
+  expect(r?.kind).toBe("clientError");
+});
+
+test("parse.args runs before validate.args (string → number coercion)", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+
+  const r = await clickAndAwaitResult("v-parsed-number-ok");
+  expect(r).toMatchObject({ kind: "ok", n: 42, handlerRan: true });
+});
+
+test("parse.args producing NaN fails validate.args", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+
+  const r = await clickAndAwaitResult("v-parsed-number-bad");
+  expect(r?.kind).toBe("clientError");
+});
+
+test("validation failure: handler must not run (no server-side side effect)", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+
+  // Reset shared marker.
+  await clickAndAwaitResult("v-reset-side-effect");
+
+  // Trigger a validation failure on `tooShort`.
+  const err = await clickAndAwaitResult("v-too-short");
+  expect(err?.kind).toBe("clientError");
+
+  // Read the marker — if the handler ran (bug), it would be "hi".
+  const marker = await clickAndAwaitResult("v-too-short-side-effect");
+  expect(marker).toBe(null);
+});
+
+test("formData upload — happy path", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+
+  const r = await clickAndAwaitResult("v-upload-ok");
+  expect(r).toMatchObject({
+    kind: "ok",
+    title: "hello",
+    photoSize: 16,
+    photoType: "image/png",
+    handlerRan: true,
+  });
+});
+
+test("formData upload — oversize file rejected", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+
+  const r = await clickAndAwaitResult("v-upload-oversize");
+  expect(r?.kind).toBe("clientError");
+});
+
+test("formData upload — wrong MIME rejected", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+
+  const r = await clickAndAwaitResult("v-upload-bad-mime");
+  expect(r?.kind).toBe("clientError");
+});
+
+test("formData upload — injected unknown key rejected", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+
+  const r = await clickAndAwaitResult("v-upload-injected");
+  expect(r?.kind).toBe("clientError");
+});
+
+test("bare 'use server' export without createFunction works unchanged", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+
+  const r = await clickAndAwaitResult("v-bare-echo");
+  expect(r).toMatchObject({
+    kind: "ok",
+    value: { shape: "anything" },
+    handlerRan: true,
+  });
+});
+
+// ─── Wire-aware Flight-protocol helpers ─────────────────────────────────
+//
+// Each pair below covers one helper end-to-end through the dev runtime:
+// the happy path proves the wire round-trip + handler sees the right
+// platform type, and the rejection path proves the slot-walk aborts
+// before the handler can run (or, for streams/iterables, that the
+// handler observes a `drainError` set by the wrapped consumer).
+
+test("arrayBuffer — happy path", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+  const r = await clickAndAwaitResult("v-ab-ok");
+  expect(r).toMatchObject({
+    kind: "ok",
+    isArrayBuffer: true,
+    byteLength: 4,
+    first: 1,
+    handlerRan: true,
+  });
+});
+
+test("arrayBuffer — oversize rejected", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+  const r = await clickAndAwaitResult("v-ab-oversize");
+  expect(r?.kind).toBe("clientError");
+});
+
+test("typedArray — happy path with declared ctor", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+  const r = await clickAndAwaitResult("v-ta-ok");
+  expect(r).toMatchObject({
+    kind: "ok",
+    ctor: "Uint8Array",
+    byteLength: 4,
+    first: 5,
+    handlerRan: true,
+  });
+});
+
+test("typedArray — wrong ctor rejected", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+  const r = await clickAndAwaitResult("v-ta-bad-ctor");
+  expect(r?.kind).toBe("clientError");
+});
+
+test("typedArray — oversize rejected", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+  const r = await clickAndAwaitResult("v-ta-oversize");
+  expect(r?.kind).toBe("clientError");
+});
+
+test("map — happy path with inner key/value schemas", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+  const r = await clickAndAwaitResult("v-map-ok");
+  expect(r).toMatchObject({
+    kind: "ok",
+    isMap: true,
+    size: 2,
+    handlerRan: true,
+  });
+});
+
+test("map — oversize rejected", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+  const r = await clickAndAwaitResult("v-map-oversize");
+  expect(r?.kind).toBe("clientError");
+});
+
+test("map — bad inner value rejected", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+  const r = await clickAndAwaitResult("v-map-bad-value");
+  expect(r?.kind).toBe("clientError");
+});
+
+test("set — happy path", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+  const r = await clickAndAwaitResult("v-set-ok");
+  expect(r).toMatchObject({
+    kind: "ok",
+    isSet: true,
+    size: 2,
+    handlerRan: true,
+  });
+});
+
+test("set — oversize rejected", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+  const r = await clickAndAwaitResult("v-set-oversize");
+  expect(r?.kind).toBe("clientError");
+});
+
+test("stream — drains within cap", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+  const r = await clickAndAwaitResult("v-stream-under-cap");
+  expect(r).toMatchObject({
+    kind: "ok",
+    chunkCount: 2,
+    drainError: null,
+    handlerRan: true,
+  });
+});
+
+test("stream — wrapped consumer errors past maxChunks", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+  const r = await clickAndAwaitResult("v-stream-over-cap");
+  // The handler runs (validation gates only the slot's wire shape, not
+  // chunk contents), but its `drainError` must be set when the wrapper
+  // reaches the cap. That's the contract: bounds enforced as the
+  // handler consumes, not at decode.
+  expect(r?.kind).toBe("ok");
+  expect(r?.handlerRan).toBe(true);
+  expect(r?.drainError).toMatch(/max_chunks_exceeded/);
+});
+
+test("asyncIterable — yields within cap and inner schema", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+  const r = await clickAndAwaitResult("v-aiter-ok");
+  expect(r).toMatchObject({
+    kind: "ok",
+    yields: [1, 2],
+    drainError: null,
+  });
+});
+
+test("asyncIterable — over-yield surfaces as drainError", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+  const r = await clickAndAwaitResult("v-aiter-overyield");
+  expect(r?.kind).toBe("ok");
+  expect(r?.drainError).toMatch(/max_yields_exceeded/);
+});
+
+test("asyncIterable — bad-value yield surfaces as drainError", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+  const r = await clickAndAwaitResult("v-aiter-bad-value");
+  expect(r?.kind).toBe("ok");
+  expect(r?.drainError).toMatch(/validate_failed/);
+});
+
+test("iterable — sync iteration with caps", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+  const r = await clickAndAwaitResult("v-iter-ok");
+  expect(r).toMatchObject({
+    kind: "ok",
+    yields: [1, 2],
+    drainError: null,
+  });
+});
+
+test("iterable — over-yield surfaces as drainError", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+  const r = await clickAndAwaitResult("v-iter-overyield");
+  expect(r?.kind).toBe("ok");
+  expect(r?.drainError).toMatch(/max_yields_exceeded/);
+});
+
+test("promise — resolves through inner schema", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+  const r = await clickAndAwaitResult("v-promise-ok");
+  expect(r).toMatchObject({
+    kind: "ok",
+    value: "hello",
+    awaitError: null,
+  });
+});
+
+test("promise — bad resolved value surfaces as awaitError", async () => {
+  await server("fixtures/server-function-validation.jsx");
+  await page.goto(hostname);
+  await waitForHydration();
+  const r = await clickAndAwaitResult("v-promise-bad-value");
+  expect(r?.kind).toBe("ok");
+  expect(r?.awaitError).toMatch(/validate_failed/);
+});

--- a/test/fixtures/server-function-validation-actions.mjs
+++ b/test/fixtures/server-function-validation-actions.mjs
@@ -1,0 +1,284 @@
+"use server";
+
+/**
+ * Server-function validation fixture: a small set of actions wrapped with
+ * `createFunction({...})(handler)` so the spec can drive them from the
+ * browser and assert that the protocol-level slot-walk rejects on
+ * specification mismatch — before any handler code runs.
+ *
+ * The handlers themselves are intentionally trivial: if they ever
+ * execute, the test should observe a non-error result, which is how we
+ * verify the "validation aborted before handler" contract — the
+ * negative test paths must never reach the assignment in the handler.
+ */
+
+import {
+  createFunction,
+  formData,
+  file,
+  arrayBuffer,
+  typedArray,
+  map,
+  set,
+  stream,
+  asyncIterable,
+  iterable,
+  promise,
+} from "@lazarv/react-server/function";
+
+// Minimal Standard-Schema duck-types — keeps the fixture dep-light. The
+// runtime's `safeValidate` accepts any object with `safeParse` /
+// `assert` / `parse`. We use `safeParse` here.
+function strSchema() {
+  return {
+    safeParse(v) {
+      if (typeof v === "string") return { success: true, data: v };
+      return { success: false, error: { message: "expected string" } };
+    },
+  };
+}
+function numSchema() {
+  return {
+    safeParse(v) {
+      if (typeof v === "number" && Number.isFinite(v))
+        return { success: true, data: v };
+      return { success: false, error: { message: "expected finite number" } };
+    },
+  };
+}
+function minLen(n) {
+  return {
+    safeParse(v) {
+      if (typeof v === "string" && v.length >= n)
+        return { success: true, data: v };
+      return { success: false, error: { message: `expected min length ${n}` } };
+    },
+  };
+}
+
+// ─── Action 1: simple two-arg validation ────────────────────────────────
+//
+// Slot 0: string. Slot 1: number. Returns a description of what the
+// handler saw — the spec asserts this only when both args validated.
+
+export const greet = createFunction([strSchema(), numSchema()])(
+  async function greet(name, age) {
+    return { kind: "ok", name, age, handlerRan: true };
+  }
+);
+
+// ─── Action 2: parse → validate, in that order ──────────────────────────
+//
+// `parse[0]` coerces the wire string into a number; `validate[0]` then
+// asserts it's a finite number. Lets the spec verify parse runs before
+// validate (a "42" wire value passes; "not-a-number" fails parse).
+
+export const parsedNumber = createFunction({
+  parse: [(v) => Number(v)],
+  validate: [numSchema()],
+})(async function parsedNumber(n) {
+  return { kind: "ok", n, handlerRan: true };
+});
+
+// ─── Action 3: validation rejects → handler never runs ──────────────────
+//
+// Slot 0 requires a 5-char minimum. Spec calls with a too-short string
+// and asserts the client receives an error AND the handler did NOT
+// observe the call (no global side-effect set).
+
+let sideEffectMarker = null;
+export function readSideEffect() {
+  return sideEffectMarker;
+}
+export function resetSideEffect() {
+  sideEffectMarker = null;
+  return true;
+}
+
+export const tooShort = createFunction([minLen(5)])(async function tooShort(s) {
+  // If the slot-walk is broken and this runs, the side effect surfaces
+  // in a follow-up readSideEffect() call from the spec.
+  sideEffectMarker = s;
+  return { kind: "ok", s, handlerRan: true };
+});
+
+// ─── Action 4: formData with file() entry ────────────────────────────
+//
+// Slot 0 is a sub-FormData with declared `title` (string) and `photo`
+// (file with maxBytes + mime). The handler returns what it read from
+// the validated FormData. The spec drives both happy-path and
+// rejection-path (oversize file, wrong MIME, injected key).
+
+export const upload = createFunction([
+  formData({
+    title: strSchema(),
+    photo: file({
+      maxBytes: 64,
+      mime: ["image/png", "image/jpeg"],
+    }),
+  }),
+])(async function upload(form) {
+  const photo = form.get("photo");
+  return {
+    kind: "ok",
+    title: form.get("title"),
+    photoSize: photo?.size ?? null,
+    photoType: photo?.type ?? null,
+    handlerRan: true,
+  };
+});
+
+// ─── Wire-aware Flight-protocol helpers ─────────────────────────────────
+//
+// Each handler covers one wire-aware spec from
+// `@lazarv/react-server/function`. Tests drive both happy-path inputs
+// (handler runs and reports back what it observed) and rejection
+// inputs (handler must NOT run; client receives an error). The spec
+// reads `kind` to distinguish the two outcomes, and the size /
+// constructor / chunk-count fields to confirm the value the slot-walk
+// passed through.
+
+// arrayBuffer — caps at 16 bytes. Oversize → max_bytes_exceeded.
+export const echoArrayBuffer = createFunction([arrayBuffer({ maxBytes: 16 })])(
+  async function echoArrayBuffer(buf) {
+    return {
+      kind: "ok",
+      isArrayBuffer: buf instanceof ArrayBuffer,
+      byteLength: buf.byteLength,
+      first: new Uint8Array(buf)[0],
+      handlerRan: true,
+    };
+  }
+);
+
+// typedArray — only Uint8Array allowed, up to 16 bytes. Float32Array
+// payloads → wire_shape_mismatch. Larger Uint8Array → max_bytes_exceeded.
+export const echoTypedArray = createFunction([
+  typedArray({ ctor: Uint8Array, maxBytes: 16 }),
+])(async function echoTypedArray(arr) {
+  return {
+    kind: "ok",
+    ctor: arr.constructor.name,
+    byteLength: arr.byteLength,
+    first: arr[0],
+    handlerRan: true,
+  };
+});
+
+// map — caps at 3 entries; values must be numbers.
+export const echoMap = createFunction([
+  map({ maxSize: 3, key: strSchema(), value: numSchema() }),
+])(async function echoMap(m) {
+  return {
+    kind: "ok",
+    isMap: m instanceof Map,
+    size: m.size,
+    entries: [...m.entries()],
+    handlerRan: true,
+  };
+});
+
+// set — caps at 3 items; items must be strings.
+export const echoSet = createFunction([
+  set({ maxSize: 3, value: strSchema() }),
+])(async function echoSet(s) {
+  return {
+    kind: "ok",
+    isSet: s instanceof Set,
+    size: s.size,
+    items: [...s].toSorted(),
+    handlerRan: true,
+  };
+});
+
+// stream — caps at 3 chunks. Reading a 4th chunk through the wrapped
+// stream errors at the consumer. The handler drains and reports.
+export const echoStream = createFunction([stream({ maxChunks: 3 })])(
+  async function echoStream(s) {
+    const chunks = [];
+    let drainError = null;
+    const reader = s.getReader();
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+      }
+    } catch (err) {
+      drainError = String(err?.reason ?? err?.message ?? err);
+    }
+    return {
+      kind: "ok",
+      chunkCount: chunks.length,
+      drainError,
+      handlerRan: true,
+    };
+  }
+);
+
+// asyncIterable — caps at 2 yields; values must be numbers.
+export const echoAsyncIterable = createFunction([
+  asyncIterable({ maxYields: 2, value: numSchema() }),
+])(async function echoAsyncIterable(it) {
+  const collected = [];
+  let drainError = null;
+  try {
+    for await (const v of it) collected.push(v);
+  } catch (err) {
+    drainError = String(err?.reason ?? err?.message ?? err);
+  }
+  return {
+    kind: "ok",
+    yields: collected,
+    drainError,
+    handlerRan: true,
+  };
+});
+
+// iterable — sync, caps at 2 yields. Same shape as the async case.
+export const echoIterable = createFunction([
+  iterable({ maxYields: 2, value: numSchema() }),
+])(async function echoIterable(it) {
+  const collected = [];
+  let drainError = null;
+  try {
+    for (const v of it) collected.push(v);
+  } catch (err) {
+    drainError = String(err?.reason ?? err?.message ?? err);
+  }
+  return {
+    kind: "ok",
+    yields: collected,
+    drainError,
+    handlerRan: true,
+  };
+});
+
+// promise — resolved value must be a string.
+export const echoPromise = createFunction([promise(strSchema())])(
+  async function echoPromise(p) {
+    let value = null;
+    let awaitError = null;
+    try {
+      value = await p;
+    } catch (err) {
+      awaitError = String(err?.reason ?? err?.message ?? err);
+    }
+    return {
+      kind: "ok",
+      value,
+      awaitError,
+      handlerRan: true,
+    };
+  }
+);
+
+// ─── Final action: bare "use server" without createFunction ─────────────
+//
+// Same module, same `"use server"` directive — no `createFunction`
+// wrapper, so no meta is registered. Spec calls with anything and
+// asserts the handler runs unchanged (legacy walk path).
+
+export async function bareEcho(value) {
+  return { kind: "ok", value, handlerRan: true };
+}

--- a/test/fixtures/server-function-validation-client.jsx
+++ b/test/fixtures/server-function-validation-client.jsx
@@ -1,0 +1,222 @@
+"use client";
+
+import {
+  greet,
+  parsedNumber,
+  tooShort,
+  upload,
+  bareEcho,
+  readSideEffect,
+  resetSideEffect,
+  echoArrayBuffer,
+  echoTypedArray,
+  echoMap,
+  echoSet,
+  echoStream,
+  echoAsyncIterable,
+  echoIterable,
+  echoPromise,
+} from "./server-function-validation-actions.mjs";
+
+/**
+ * Driver for the createFunction validation E2E test. Each button
+ * invokes one server function with a specific input, stashes the result
+ * (or the error message) on `window.__react_server_result__`, and the
+ * Playwright spec asserts on the captured shape. We carry the error
+ * message text over rather than the original Error object because the
+ * client side only sees a transport-stripped error from the runtime.
+ */
+export default function ServerFunctionValidationClient() {
+  const call = (name, run) => (
+    <button
+      key={name}
+      data-testid={name}
+      onClick={async () => {
+        window.__react_server_result__ = undefined;
+        try {
+          const r = await run();
+          window.__react_server_result__ = r;
+        } catch (e) {
+          window.__react_server_result__ = {
+            kind: "clientError",
+            message: String(e?.message ?? e),
+          };
+        }
+      }}
+    >
+      {name}
+    </button>
+  );
+
+  return (
+    <>
+      {/* dev-mode double render */}
+      <div suppressHydrationWarning>{Math.random()}</div>
+
+      {call("v-greet-ok", () => greet("alice", 30))}
+      {call("v-greet-bad-arg-0", () => greet(123, 30))}
+      {call("v-greet-bad-arg-1", () => greet("alice", "thirty"))}
+
+      {call("v-parsed-number-ok", () => parsedNumber("42"))}
+      {call("v-parsed-number-bad", () => parsedNumber("not-a-number"))}
+
+      {call("v-too-short", () => tooShort("hi"))}
+      {call("v-too-short-side-effect", async () => readSideEffect())}
+      {call("v-reset-side-effect", async () => resetSideEffect())}
+
+      {call("v-upload-ok", async () => {
+        const fd = new FormData();
+        fd.append("title", "hello");
+        fd.append(
+          "photo",
+          new File([new Uint8Array(16)], "p.png", { type: "image/png" })
+        );
+        return upload(fd);
+      })}
+      {call("v-upload-oversize", async () => {
+        const fd = new FormData();
+        fd.append("title", "hello");
+        fd.append(
+          "photo",
+          new File([new Uint8Array(128)], "p.png", { type: "image/png" })
+        );
+        return upload(fd);
+      })}
+      {call("v-upload-bad-mime", async () => {
+        const fd = new FormData();
+        fd.append("title", "hello");
+        fd.append(
+          "photo",
+          new File([new Uint8Array(8)], "p.gif", { type: "image/gif" })
+        );
+        return upload(fd);
+      })}
+      {call("v-upload-injected", async () => {
+        const fd = new FormData();
+        fd.append("title", "hello");
+        fd.append(
+          "photo",
+          new File([new Uint8Array(8)], "p.png", { type: "image/png" })
+        );
+        // Attacker-style extra field — the default `unknown` policy
+        // ("reject") catches this before any handler runs.
+        fd.append("role", "admin");
+        return upload(fd);
+      })}
+
+      {/* arrayBuffer */}
+      {call("v-ab-ok", () =>
+        echoArrayBuffer(new Uint8Array([1, 2, 3, 4]).buffer)
+      )}
+      {call("v-ab-oversize", () => echoArrayBuffer(new Uint8Array(64).buffer))}
+
+      {/* typedArray */}
+      {call("v-ta-ok", () => echoTypedArray(new Uint8Array([5, 6, 7, 8])))}
+      {call("v-ta-bad-ctor", () => echoTypedArray(new Float32Array([1.5])))}
+      {call("v-ta-oversize", () => echoTypedArray(new Uint8Array(64)))}
+
+      {/* map */}
+      {call("v-map-ok", () =>
+        echoMap(
+          new Map([
+            ["a", 1],
+            ["b", 2],
+          ])
+        )
+      )}
+      {call("v-map-oversize", () =>
+        echoMap(
+          new Map([
+            ["a", 1],
+            ["b", 2],
+            ["c", 3],
+            ["d", 4],
+          ])
+        )
+      )}
+      {call("v-map-bad-value", () => echoMap(new Map([["a", "not-a-number"]])))}
+
+      {/* set */}
+      {call("v-set-ok", () => echoSet(new Set(["a", "b"])))}
+      {call("v-set-oversize", () => echoSet(new Set(["a", "b", "c", "d"])))}
+
+      {/* stream — wrapped at the consumer; handler observes drainError */}
+      {call("v-stream-under-cap", () =>
+        echoStream(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue("a");
+              controller.enqueue("b");
+              controller.close();
+            },
+          })
+        )
+      )}
+      {call("v-stream-over-cap", () =>
+        echoStream(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue("a");
+              controller.enqueue("b");
+              controller.enqueue("c");
+              controller.enqueue("d");
+              controller.close();
+            },
+          })
+        )
+      )}
+
+      {/* asyncIterable */}
+      {call("v-aiter-ok", () =>
+        echoAsyncIterable(
+          (async function* () {
+            yield 1;
+            yield 2;
+          })()
+        )
+      )}
+      {call("v-aiter-overyield", () =>
+        echoAsyncIterable(
+          (async function* () {
+            yield 1;
+            yield 2;
+            yield 3;
+          })()
+        )
+      )}
+      {call("v-aiter-bad-value", () =>
+        echoAsyncIterable(
+          (async function* () {
+            yield 1;
+            yield "not-a-number";
+          })()
+        )
+      )}
+
+      {/* iterable */}
+      {call("v-iter-ok", () =>
+        echoIterable(
+          (function* () {
+            yield 1;
+            yield 2;
+          })()
+        )
+      )}
+      {call("v-iter-overyield", () =>
+        echoIterable(
+          (function* () {
+            yield 1;
+            yield 2;
+            yield 3;
+          })()
+        )
+      )}
+
+      {/* promise */}
+      {call("v-promise-ok", () => echoPromise(Promise.resolve("hello")))}
+      {call("v-promise-bad-value", () => echoPromise(Promise.resolve(42)))}
+
+      {call("v-bare-echo", () => bareEcho({ shape: "anything" }))}
+    </>
+  );
+}

--- a/test/fixtures/server-function-validation.jsx
+++ b/test/fixtures/server-function-validation.jsx
@@ -1,0 +1,10 @@
+import ServerFunctionValidationClient from "./server-function-validation-client.jsx";
+
+export default function ServerFunctionValidation() {
+  return (
+    <>
+      <h1>server-function validation</h1>
+      <ServerFunctionValidationClient />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

This PR closes the third and final piece of the server-function security series. PR #421 made the action token tamper-evident; PR #422 added the kill-switch for apps that don't use server functions at all. What was still missing — and what this lands — is a way to declare *what shape* an action expects from the wire, so the runtime can reject malformed payloads at the protocol layer instead of letting them reach handler code where intent is lost.

The API is `createFunction`, exported from a new `@lazarv/react-server/function` subpath. It wraps a `"use server"` handler with a per-arg parse/validate spec, the bundler forwards that spec to `registerServerReference`, and the protocol decoder consults it on every call. Bad inputs are caught during decode and the request fails with `HTTP 400` and an `x-react-server-action-error: <reason>` header before any handler code runs. Bare `"use server"` actions without `createFunction` keep working unchanged — validation is opt-in and additive.

## The API

The most common shape is the array shorthand: `createFunction([z.string(), z.number()])(handler)`. The slot index is the *runtime arg slot* — what the client puts on the wire at position `i` — not the handler signature param. When you also need pre-validate parsing, the object form takes both arrays explicitly: `createFunction({ parse: [...], validate: [...] })(handler)`. The no-spec form `createFunction()(handler)` exists too; it attaches the marker so the dev-strict warning treats the export as deliberately unvalidated. Bound captures (closure values from `.bind(...)` or render-time closures) are explicitly *not* part of the validation contract — they're integrity-protected by the AEAD action token from #421, not validated as user inputs.

The full TypeScript story comes for free with this API. The handler's parameter types are inferred from the schemas via the same `ValidateSchema<T>` / `InferSchema<T>` machinery the typed router already uses, so any Standard Schema (Zod, Valibot, ArkType, generic `.parse()`) works as a slot constraint. Hovering an `addEntry` call site that was declared with `z.object({ name: z.string() })` shows `(input: { name: string }) => Promise<…>` — derived directly from the schema, no manual type annotation. Misuse at the call site is a TypeScript error, not a runtime surprise.

## Wire-aware helpers

A Standard Schema isn't enough for every Flight wire type. Some validations need to bound resource consumption before the handler observes the value (file uploads, byte buffers); some need to wrap an async source so the bound is enforced as the handler consumes (streams, async iterables); some need a constructor allowlist that's narrowed in TypeScript via `instanceof` rather than a string-name lookup (typed arrays). For each of those cases there's a dedicated wire-aware helper. `formData(shape, options?)` declares a sub-FormData with declared-key entries (no prefix scan, an attacker-injected `5_role=admin` is rejected by default), and inside it `file({ maxBytes, mime })` and `blob(...)` enforce per-entry size and MIME synchronously against `Blob.size` / `Blob.type`. `arrayBuffer({ maxBytes })` caps byte length on `$AB`, `typedArray({ ctor: Float32Array, maxBytes })` does the same for `$AT` while narrowing the inferred handler type to the exact `Float32Array` instance. `map({ maxSize, key, value })` and `set({ maxSize, value })` cap collection size and route inner key/value validation through the same Standard Schema bridge. `stream({ maxChunks, maxBytes })` covers both the text (`$r`) and binary (`$b`) Flight stream tags by wrapping the materialized `ReadableStream` in a `TransformStream` that errors instead of yielding past the cap. `asyncIterable({ maxYields, value })` and `iterable(...)` do the same for `$x` and `$X`, with each yielded value flowing through the inner schema as the handler pulls. `promise(value)` wraps `$@` so the resolved value runs through the schema before reaching the handler. There's also a `noop` export — an identity sentinel that reads as intent at the call site when only some slots need validation, so users don't have to write sparse-array literals or bare `undefined`.

## Decoder integration and error semantics

In `@lazarv/rsc`, `registerServerReference` gained an optional fourth `meta` argument and a paired `lookupServerFunctionMeta` for hosts to query at decode time. `decodeReply`'s options grew `actionId`, `resolveServerFunctionMeta`, and `validateArg` hooks; when all three are present the decoder switches from the legacy whole-tree walk to the new slot-walk in `walkArgsWithMeta`, which applies parse → validate slot-by-slot and aborts on the first failure with a new `DecodeValidationError`. The error carries the failing `argIndex`, the recovered `actionId`, a coarse `reason` code (`validate_failed`, `parse_failed`, `unknown_entry`, `max_bytes_exceeded`, `max_size_exceeded`, `max_chunks_exceeded`, `max_yields_exceeded`, `mime_not_allowed`, `wire_shape_mismatch`, `missing_entry`, `duplicate_entry`, `custom_validate_failed`, `max_bound_args_exceeded`), and the underlying schema diagnostic in `original`. The legacy `$h` path in `shared.mjs` got a parallel structural defense-in-depth pass: when an action has registered meta and the encrypted token already delivered bound captures, any non-empty wire-supplied `parsed.bound` is rejected as a wire-shape mismatch — the trusted channel for closure captures is the AEAD-protected token, not the wire's `bound` field.

## Dispatcher and dev guardrail

In `render-rsc.jsx`, the action-call dispatch now pre-resolves the action id (header decrypt or `$ACTION_ID_*` form-field scan) *before* `decodeReply`, then preloads the action's source module via `requireModule` so the meta registry is populated by the time the slot-walk asks for it. Without this preload, every action's first invocation would silently skip validation because the registry is filled by the module's top-level `registerServerReference` calls, which run only after import. Validation failures map to HTTP 400 with the reason in `x-react-server-action-error`. Schema diagnostics deliberately don't travel to the client — they can leak expected-shape details that aid attackers — but they're written to the server log via `logger.warn` for operator visibility. There's also a dev-only guardrail: each unwrapped `"use server"` action logs a one-time warning the first time it's called, naming the action in the same `<modulePath>#<exportName>` form the registry keys on, in a styled message that distinguishes file paths (gray italic) from JS code (magenta) and import specifiers (cyan). Set `config.serverFunctions.strict = false` to silence it during incremental migrations.